### PR TITLE
Theme cycle feature added with dark | light | system modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "physicshub",
   "homepage": "https://physicshub.github.io",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/Theme.tsx
+++ b/src/components/Theme.tsx
@@ -1,8 +1,8 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faSun, faMoon } from '@fortawesome/free-solid-svg-icons';
+import { faSun, faMoon, faCircleHalfStroke } from '@fortawesome/free-solid-svg-icons';
 
 interface Props {
-  mode: 'light' | 'dark';
+  mode: 'light' | 'dark' | 'system';
   onToggle: () => void;
 }
 
@@ -13,7 +13,11 @@ export function Theme({ mode, onToggle }: Props) {
       onClick={onToggle}
       aria-label="Toggle theme"
     >
-      <FontAwesomeIcon icon={mode === 'dark' ? faSun : faMoon} />
+     <FontAwesomeIcon icon={
+    mode === 'dark' ? faMoon :
+    mode === 'light' ? faSun :
+    faCircleHalfStroke
+} />
     </button>
   );
 }

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,14 +1,36 @@
 import { useState, useEffect, useCallback } from 'react';
 
-export function useTheme(defaultMode: 'light' | 'dark' = 'dark') {
+export function useTheme(defaultMode: 'light' | 'dark' | 'system' = 'system') {
   const [mode, setMode] = useState(defaultMode);
 
-  useEffect(() => {
-    document.body.dataset.theme = mode;
-  }, [mode]);
+  const getSystemTheme = () => {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+
+ useEffect(() => {
+  let actualTheme = mode;
+  if(mode === 'system'){
+    actualTheme = getSystemTheme();
+  }
+  document.body.dataset.theme = actualTheme;
+  if(mode === 'system'){
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = () => {
+      document.body.dataset.theme = getSystemTheme();
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return ()=> mediaQuery.removeEventListener('change', handleChange);
+  }
+}, [mode]);
 
   const toggleMode = useCallback(
-    () => setMode(prev => (prev === 'dark' ? 'light' : 'dark')),
+    () => setMode(prev => {
+    if(prev === 'dark') return 'light';
+    if(prev === 'light') return 'system';
+    return 'dark';
+    }),
     []
   );
 


### PR DESCRIPTION
## Changes
Modified the theme toggle functionality to support three modes instead of two:
- Updated `useTheme.tsx` to include system theme detection using `window.matchMedia('prefers-color-scheme: dark')`
- Added dynamic listener to respond to OS/browser theme changes in real-time
- Modified `Theme.tsx` to display appropriate icons for each mode (moon, sun, half-circle)
- Incremented version in `package.json` from 2.2.1 to 2.3.0 according to  semantic versioning

## Why Needed
Users previously could only toggle between dark and light modes manually. This enhancement adds a system mode that automatically follows the user's OS/browser theme preference, providing a more seamless experience for users who have already configured their system-wide theme settings.

Closes #16 

## Testing
 
Verification can be made:
- Click the theme  toggle to go through all three options
- In system mode, verify the website matches your OS/browser theme preference
- Change your OS theme to confirm automatic updates (can be done via browser DevTools theme emulation)

