### PR TITLE
Fix: correct tags in simulation chapter cards 

### DIFF
--- a/src/data/chapters.js
+++ b/src/data/chapters.js
@@ -151,7 +151,7 @@ function draw(){
       desc:"Vector Operations in real time.",
       link:"/VectorsOperations",
       tags:[
-         TAGS.MEDIUM, 
+         TAGS.EASY, 
          TAGS.MATH, 
          TAGS.VECTORS, 
          TAGS.PHYSICS
@@ -230,7 +230,7 @@ function draw(){
       desc:"Ball accelerating to the mouse direction.",
       link:"/BallAcceleration",
       tags:[
-         TAGS.ADVANCED,
+         TAGS.MEDIUM,
          TAGS.PHYSICS,
          TAGS.ACCELERATION
       ],
@@ -373,8 +373,9 @@ function draw(){
       desc:"Ball fall and bounce on the ground.",
       link:"/BallGravity",
       tags:[
-         TAGS.EASY,
-         TAGS.VECTORS,
+         TAGS.MEDIUM,
+         TAGS.COLLISION,
+         TAGS.PHYSICS,
          TAGS.GRAVITY
       ],
       // Placeholder: theory section still in development
@@ -516,9 +517,10 @@ function draw(){
       desc:"A Ball connected to a string.",
       link:"/SpringConnection",
       tags:[
-         TAGS.EASY,
-         TAGS.VECTORS,
-         TAGS.GRAVITY
+         TAGS.ADVANCED,
+         TAGS.PHYSICS,
+         TAGS.OSCILLATIONS,
+         TAGS.SPRINGS
       ],
       // Placeholder: theory section still in development
       theory:{
@@ -660,8 +662,8 @@ function draw(){
       link:"/SimplePendulum",
       tags:[
          TAGS.MEDIUM,
-         TAGS.VECTORS,
-         TAGS.GRAVITY,
+         TAGS.OSCILLATIONS,
+         TAGS.ENERGY,
          TAGS.PHYSICS
       ],
       theory:{

--- a/src/data/tags.js
+++ b/src/data/tags.js
@@ -39,5 +39,17 @@ export const TAGS = {
     name: "Gravity", 
     color: "grey", 
   },
+  OSCILLATIONS: { 
+    name: "Oscillations", 
+    color: "pink", 
+  },
+  SPRINGS: { 
+    name: "Springs", 
+    color: "orange", 
+  },
+  ENERGY: { 
+    name: "Energy", 
+    color: "coral", 
+  },
 
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -674,6 +674,21 @@ footer {
   box-shadow: 0 0 8px #adb5bd;
 }
 
+.tag-pink {
+  background: linear-gradient(135deg, #e83e8c, #ff6fba);
+  box-shadow: 0 0 8px #ff6fba;
+}
+
+.tag-orange {
+  background: linear-gradient(135deg, #fd7e14, #ffb07c);
+  box-shadow: 0 0 8px #fd7e14;
+}
+
+.tag-coral {
+  background: linear-gradient(135deg, #ff6f61, #ff9a8d);
+  box-shadow: 0 0 8px #ff9a8d;
+}
+
 /* Screen */
 .screen {
   flex: 2;


### PR DESCRIPTION
closes #41 
Fixed all the tags in the simulation chapter cards
<img width="1920" height="890" alt="image" src="https://github.com/user-attachments/assets/ffe5ab14-f82f-47a1-9dae-b999a2764331" />
