### PR TITLE
fix(bouncing-ball): prevent background color shift when trail is toggled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "physicshub",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "physicshub",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.1.0",

--- a/src/utils/drawUtils.js
+++ b/src/utils/drawUtils.js
@@ -2,14 +2,25 @@
 /**
  * Draw background or trail depending on flag.
  */
-export const drawBackground = (p, bg, trailEnabled, trailLayer) => {
-  if (trailEnabled) {
-    trailLayer.noStroke();
-    trailLayer.fill(bg[0], bg[1], bg[2], 40); // dissolvenza
-    trailLayer.rect(0, 0, p.width, p.height);
-  } else {
-    trailLayer.clear();
+export const drawBackground = (p, bg, trailEnabled) => {
+  p.colorMode && p.colorMode(p.RGB, 255);
+  const bgColor =
+    Array.isArray(bg) && bg.length >= 3
+      ? p.color(bg[0], bg[1], bg[2])
+      : p.color(0, 0, 0);
+
+  if (!trailEnabled) {
+    p.background(p.red(bgColor), p.green(bgColor), p.blue(bgColor));
+    return;
   }
+  const trailAlpha = 60;
+  p.push();
+  p.rectMode && p.rectMode(p.CORNER);
+  p.noStroke();
+  p.blendMode && p.blendMode(p.BLEND);
+  p.fill(p.red(bgColor), p.green(bgColor), p.blue(bgColor), trailAlpha);
+  p.rect(0, 0, p.width, p.height);
+  p.pop();
 };
 
 /**


### PR DESCRIPTION
This PR fixes #14 a visual bug in the BouncingBall simulation where toggling the "Enable trail" option caused the canvas background to appear slightly lighter.

The issue was caused by inconsistent color blending between the trail and non-trail modes in drawBackground().
The fix ensures consistent RGB usage and alpha blending so that the background color remains identical whether the trail is enabled or not.

Updated `src/utils/drawUtils.js` to:
- Set `colorMode(RGB, 255)` for consistent alpha interpretation.
- Use a single `p.color()` object derived from `getBackgroundColor()` for both full clears and translucent overlays.