### PR TITLE
fix: prevent window is undefined error in controls components

### DIFF
--- a/app/components/controls/EmbedCodeControl.jsx
+++ b/app/components/controls/EmbedCodeControl.jsx
@@ -4,9 +4,16 @@ import { useMemo } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode } from "@fortawesome/free-solid-svg-icons";
 
-export default function EmbedCodeControl({ simulation, inputs, width = 600, height = 400 }) {
+export default function EmbedCodeControl({
+  simulation,
+  inputs,
+  width = 600,
+  height = 400,
+}) {
   // Build URL with query parameters
   const url = useMemo(() => {
+    //useMemo hook grabs window immedialtely causing error during server side rendering
+    if (typeof window === "undefined") return "";
     const params = new URLSearchParams(inputs).toString();
     return `${window.location.origin}/${simulation}?${params}`;
   }, [simulation, inputs]);
@@ -20,8 +27,12 @@ export default function EmbedCodeControl({ simulation, inputs, width = 600, heig
   };
 
   return (
-    <button onClick={handleCopy} className="btn-glow" title="Copy embed code to clipboard">
-        <FontAwesomeIcon icon={faCode} />
+    <button
+      onClick={handleCopy}
+      className="btn-glow"
+      title="Copy embed code to clipboard"
+    >
+      <FontAwesomeIcon icon={faCode} />
     </button>
   );
 }

--- a/app/components/controls/ShareLinkControl.jsx
+++ b/app/components/controls/ShareLinkControl.jsx
@@ -7,6 +7,7 @@ import { faShare } from "@fortawesome/free-solid-svg-icons";
 export default function ShareLinkControl({ simulation, inputs }) {
   // Build URL with query parameters
   const url = useMemo(() => {
+    if (typeof window === "undefined") return "";
     const params = new URLSearchParams(inputs).toString();
     return `${window.location.origin}/${simulation}?${params}`;
   }, [simulation, inputs]);
@@ -17,8 +18,12 @@ export default function ShareLinkControl({ simulation, inputs }) {
   };
 
   return (
-    <button onClick={handleCopy} className="btn-glow" title="Copy shareable link to clipboard">
-        <FontAwesomeIcon icon={faShare} />
+    <button
+      onClick={handleCopy}
+      className="btn-glow"
+      title="Copy shareable link to clipboard"
+    >
+      <FontAwesomeIcon icon={faShare} />
     </button>
   );
 }


### PR DESCRIPTION
📘 Pull Request Example — your case
## 🔍 Description

Fixed a window is not defined error that occurred during Next.js build and preview.
The issue was caused by client components (EmbedCodeControl and ShareLinkControl) referencing window during SSR.

Added a safety check inside the useMemo hook:

`if (typeof window === "undefined") return "";`


This ensures code only runs in the browser and prevents SSR crashes.

Closes #97

## ✅ Checklist

 Verified that the project builds and runs locally (npm run dev, npm run preview)

 No ESLint or TypeScript warnings/errors

 Updated inline comments explaining the fix

 Confirmed UI works as expected

 Updated version in package.json (patch level, e.g. 2.7.4)

 Followed CONTRIBUTING.md guidelines

## 🎨 Visual Changes (if UI-related)

No visible UI change — internal bug fix.

## 📂 Type of Change

 🐛 Bug fix (non-breaking change that fixes an issue)

 ♻️ Refactor / code quality improvement

## 🧩 Additional Notes for Reviewers

Verified build success on Next.js 16.0.1 with no SSR or hydration errors.

Tested all simulations using ShareLinkControl and EmbedCodeControl.

Safe for merge; minimal change limited to client components.