### PR TITLE
fix: avoid duplicate p5 canvas initialization in React StrictMode

### DIFF
--- a/app/(core)/components/P5Wrapper.jsx
+++ b/app/(core)/components/P5Wrapper.jsx
@@ -1,50 +1,89 @@
-// app/components/P5Wrapper.jsx
+// app/(core)/components/P5Wrapper.jsx
 "use client";
 import { useEffect, useRef } from "react";
 import { resetTime, cleanupInstance } from "../constants/Time.js";
 
 export default function P5Wrapper({ sketch, simInfos }) {
-  const containerRef = useRef(null);
-  const p5InstanceRef = useRef(null);
+    // containerRef: the <div> where p5 will attach the canvas
+    const containerRef = useRef(null);
+    // p5InstanceRef: keeps track of the current p5 instance (so it can be removed on unmount)
+    const p5InstanceRef = useRef(null);
 
-  useEffect(() => {
-    let p5;
-    (async () => {
-      const module = await import("p5"); // ✅ import dinamico
-      p5 = module.default;
-
-      if (p5InstanceRef.current) {
-        cleanupInstance(p5InstanceRef.current);
-        p5InstanceRef.current.remove();
-        p5InstanceRef.current = null;
-      }
-
-      const p5Instance = new p5((p) => {
-        p._instanceId = crypto?.randomUUID
-          ? crypto.randomUUID()
-          : Math.random().toString(36).substring(2) + Date.now().toString(36);
-
-        resetTime();
-        sketch(p);
-      }, containerRef.current);
-
-      p5InstanceRef.current = p5Instance;
-    })();
-
-    return () => {
-      if (p5InstanceRef.current) {
-        cleanupInstance(p5InstanceRef.current);
-        p5InstanceRef.current.remove();
-        p5InstanceRef.current = null;
-      }
+    // Cleanup helper function to safely remove a p5 instance
+    const safeRemove = (instance) => {
+        if (!instance) return;
+        try {
+            cleanupInstance(instance);
+            instance.remove();
+        } catch {
+            // Errors are intentionally silenced
+            // as p5 removal can be flaky in some edge cases
+            // (e.g., Fast Refresh, unmount during loading, etc.)
+            // this prevents noise in the console.
+        }
     };
-  }, [sketch]);
 
-  return (
-    <div className="p5-wrapper">
-      <div ref={containerRef} className="screen" id="Screen">
-        {simInfos ?? ""}
-      </div>
-    </div>
-  );
+    useEffect(() => {
+        // Set active to true. If component unmounts, turn it to false.
+        // Active is LOCAL to this useEffect scope, so multiple mounts/unmounts
+        // won't interfere with each other.
+        let active = true;
+        let tempP5Instance = null;
+
+        // IIAFE (Immediately Invoked Async Function Expression)
+        (async () => {
+            try {
+                // P5 dynamic import (browser-only)
+                // Directly destructuring default import to avoid extra .default usage
+                const { default: p5 } = await import("p5");
+
+                // Exit if component inactive (unmounted) or sketch missing
+                if (!active || !containerRef.current || !sketch) return;
+
+                // Remove previous instance if exists (Fast Refresh / sketch change)
+                safeRemove(p5InstanceRef.current);
+                p5InstanceRef.current = null;
+
+                // Create a new P5 instance in a temporary variable.
+                // We only assign it to p5InstanceRef after confirming the component is still mounted
+                // to avoid keeping a P5 instance alive for an unmounted component.
+                tempP5Instance = new p5((p) => {
+                    p._instanceId =
+                        crypto?.randomUUID?.() ??
+                        Math.random().toString(36).slice(2) + Date.now().toString(36);
+
+                    resetTime();
+                    sketch(p);
+                }, containerRef.current);
+
+                // If component is already unmounted when the temp instance finishes loading, cleanup
+                // Very rare edge case, but good to handle
+                if (!active) {
+                    safeRemove(tempP5Instance);
+                    return;
+                }
+
+                // Confirmed mount success - track the new instance
+                p5InstanceRef.current = tempP5Instance;
+            } catch (err) {
+                console.error("Failed to load P5:", err);
+            }
+        })();
+
+        return () => {
+            active = false;
+
+            // Cleanup any existing instance
+            safeRemove(p5InstanceRef.current);
+            p5InstanceRef.current = null;
+        };
+    }, [sketch]);
+
+    return (
+        <div className="p5-wrapper">
+            <div ref={containerRef} className="screen" id="Screen">
+                {simInfos ?? ""}
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
# 📘 Pull Request Template – PhysicsHub

Thank you for contributing to **PhysicsHub**!  
Please complete the sections below to help us review your pull request efficiently.

---

## 🔍 Description
Changed ```app/(core)/components/P5Wrapper.jsx``` to fix double mounting of canvas in React StrictMode which was likely caused by async?

Specifically, I *think* the chain of events causing the original issue is:

1. in react Strictmode, **the same ref is used in the unmount/remount process**
2. p5InstanceRef starts out as null 
3. p5 canvas is created asynchronously 
4. react strictmode causes remount before canvas is fully created
5. p5InstanceRef points to null again on remount
6. asynchronous creation of first p5 canvas is completed and canvas is added to DOM directly
7. since p5ref already points to null, you cant cleanup the old instance via the ```if (p5InstanceRef.current)``` check
8. due to remount, async runs again, and another canvas is created and added to DOM
9. now you have two canvases in DOM

In this update, 

- ```let active = true;``` is added
- ```active``` is local to the useEffect, so even when the component unmounts, the original ```active``` isn't overridden, instead a new local ```active``` is created for the new useEffect
- the first async function still tracks the first ```active``` in the first useEffect, which is set to false on unmount, and the created instance is then safeRemoved

---

## ✅ Checklist
Before requesting a review, please ensure that you have:

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [x] Updated documentation, comments, or in-code explanations where needed
- [x] Verified responsiveness across devices (desktop, tablet, mobile)
- [ ] Updated version in package.json as specified on [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

---

## 🎨 Visual Changes (if UI-related)
<!-- Attach screenshots, GIFs, or screen recordings to illustrate UI/UX changes. -->

---

## 📂 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] ♻️ Refactor / code quality improvement
- [ ] 🎨 UI/UX enhancement
- [ ] 🔒 Security improvement

---

## 🧩 Additional Notes for Reviewers
Didn't update version in package.json since the CONTRIBUTING.md says it's automatic now
