### PR TITLE
Fix unclear select box styling for blog callouts

### DIFF
--- a/app/(core)/styles/theory.css
+++ b/app/(core)/styles/theory.css
@@ -1072,6 +1072,17 @@
   box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
+/* Fix: Dark mode dropdown visibility for callout type selector */
+.callout-type-selector option {
+  background-color: #1a1a1a;
+  color: #ffffff;
+}
+
+[data-theme="light"] .callout-type-selector option {
+  background-color: #ffffff;
+  color: #333333;
+}
+
 /* 10. LIST EDITING */
 .theory-list-container {
   margin: 12px 0;


### PR DESCRIPTION
### 🐛 Fix: Unclear Select Box for Blog Callouts

This PR improves the visibility of the callout type select box when creating a blog.

### ✅ Changes
- Fixed dropdown option visibility in dark mode
- Ensured proper background and text contrast
- Tested on desktop and mobile view

### 🔗 Related Issue
Closes #167