### PR TITLE
fix: align @eslint/js with eslint v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "xml-formatter": "^3.6.7"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.1",
     "@semantic-release/exec": "^7.1.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^25.0.9",


### PR DESCRIPTION
## 🔍 Description

Fixes npm `ERESOLVE` peer dependency conflict between `eslint` and `@eslint/js`.

The repository had:
- `eslint@^9.39.1`
- `@eslint/js@^10.0.1` (requires eslint v10)

This caused `npm install` to fail without `--legacy-peer-deps`.

This PR aligns `@eslint/js` with eslint v9.

Verified locally:
- `npm install`
- `npm run lint`
- `npm run build`

---

## ✅ Checklist

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [ ] Updated documentation, comments, or in-code explanations where needed
- [ ] Verified responsiveness across devices (desktop, tablet, mobile)
- [x] Followed the CONTRIBUTING.md guidelines

---

## 📂 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

//My first open source contribution :)