### PR TITLE
Fixed the block sliding beyond ground in inclined plane sim

### DIFF
--- a/simulations/InclinedPlane.jsx
+++ b/simulations/InclinedPlane.jsx
@@ -191,6 +191,18 @@ export default function InclinedPlane() {
           if (bodyRef.current.trail.enabled) {
             bodyRef.current.updateTrailOnPlane();
           }
+
+          const currentDist = bodyRef.current.planeState.posAlongPlane;
+          const currentScreenY =
+            planeRef.current.startY -
+            toPixels(currentDist) * Math.sin(angleRad);
+
+          //  the logic that defines 'bottom'
+          if (currentScreenY >= planeRef.current.startY) {
+            bodyRef.current.planeState.posAlongPlane = 0;
+            bodyRef.current.planeState.velAlongPlane = 0;
+            bodyRef.current.planeState.accAlongPlane = 0;
+          }
         }
 
         // Render scene


### PR DESCRIPTION
## 🔍 Description
Inside the inclined Plane Simulation
Previous behavior was as follows :
The block goes down under the ground line without stopping.

After Changes:
The block now stops at the bottom of the inlined plane without going forward down

Closes #228

---

## ✅ Checklist

Before requesting a review, please ensure that you have:

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [x] Updated documentation, comments, or in-code explanations where needed
- [x] Verified responsiveness across devices (desktop, tablet, mobile)
- [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

---

## 🎨 Visual Changes (if UI-related)


---

## 📂 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code quality improvement
- [ ] 🎨 UI/UX enhancement
- [ ] 🔒 Security improvement

---

## 🧩 Additional Notes for Reviewers

<!-- Highlight specific areas that need attention, potential edge cases, or architectural decisions. -->
