### PR TITLE
Fix cookie domain and add SameSite attribute

### DIFF
--- a/app/(core)/components/GoogleTranslator.jsx
+++ b/app/(core)/components/GoogleTranslator.jsx
@@ -144,8 +144,8 @@ export default function GoogleTranslator() {
       // Update cookie
       const hostname = window.location.hostname;
       const isLocal = hostname === "localhost" || hostname === "127.0.0.1";
-      const domainAttr = isLocal ? "" : `; domain=${hostname}`;
-      document.cookie = `googtrans=/en/${languageCode}; path=/ ${domainAttr}`;
+      const domainAttr = isLocal ? "" : `; domain=.${hostname}`;
+      document.cookie = `googtrans=/en/${languageCode}; path=/${domainAttr}; SameSite=Lax`;
 
       // Notify useTranslation
       window.dispatchEvent(


### PR DESCRIPTION
when I updated the `GoogleTranslate.jsx` file in my last pr I accidentally malformed the cookie path to the language selector state prevent my fix for issue `#240` from taking effect on production.

I failed to notice it because it was a subtle difference that only affects production and not the local development environment.

currently the production site still has issue #240 `[Bug]: language select doesn't have a state and it default to English on reload `
because of this