### PR TITLE
fix: number input shows 0 when empty instead of blank

### DIFF
--- a/app/(core)/components/inputs/DynamicInputs.tsx
+++ b/app/(core)/components/inputs/DynamicInputs.tsx
@@ -41,9 +41,15 @@ export default function DynamicInputs({ config, values, onChange }: Props) {
               min={field.min}
               max={field.max}
               step={field.step}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                onChange(field.name, Number(e.target.value))
-              }
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const rawValue = e.target.value;
+                // Allow empty string
+                if (rawValue === "") {
+                  onChange(field.name, "");
+                } else {
+                  onChange(field.name, Number(rawValue));
+                }
+              }}
             />
           );
         }

--- a/app/(core)/components/inputs/NumberInput.jsx
+++ b/app/(core)/components/inputs/NumberInput.jsx
@@ -15,9 +15,10 @@ function NumberInput({
         {label}
       </label>
       <input
-        type="number"
+        type="text"
+        inputMode="numeric"
         id={name}
-        value={val}
+        value={val === undefined || val === null ? "" : val}
         min={min}
         max={max}
         step={step || 1}


### PR DESCRIPTION
## Fix: Number inputs now allow empty values

### Issue
Closes #257

### What changed
- Changed NumberInput from `type="number"` to `type="text"` with `inputMode="numeric"`
- Updated onChange handler in DynamicInputs to allow empty strings
- Empty inputs now stay empty until user types a new value

### Before
When user deleted all text, value jumped to 0

### After
When user deletes all text, input becomes empty (blank)

### Testing
1. Go to any simulation
2. Click a number input
3. Press delete/backspace to erase everything
4. Input becomes empty
5. Type a new number
6. Works normally

### Screenshot
<img width="1420" height="653" alt="Screenshot 2026-04-07 at 2 12 00 PM" src="https://github.com/user-attachments/assets/bbb07d2f-24bf-4bd4-b9ab-2667f1c25882" />

