### PR TITLE
Fix: Resolved NaN issue in the Input Field

### DIFF
--- a/app/(core)/components/inputs/DynamicInputs.tsx
+++ b/app/(core)/components/inputs/DynamicInputs.tsx
@@ -43,11 +43,22 @@ export default function DynamicInputs({ config, values, onChange }: Props) {
               step={field.step}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 const rawValue = e.target.value;
+
                 // Allow empty string
                 if (rawValue === "") {
                   onChange(field.name, "");
-                } else {
-                  onChange(field.name, Number(rawValue));
+                  return;
+                }
+                // Check if it ends with a dot (user is typing decimal)
+                if (rawValue.endsWith(".")) {
+                  // Pass as string - don't convert to number yet
+                  onChange(field.name, rawValue);
+                  return;
+                }
+                // Check if it's a valid number
+                const num = parseFloat(rawValue);
+                if (!isNaN(num)) {
+                  onChange(field.name, num);
                 }
               }}
             />

--- a/app/(core)/components/inputs/DynamicInputs.tsx
+++ b/app/(core)/components/inputs/DynamicInputs.tsx
@@ -56,7 +56,7 @@ export default function DynamicInputs({ config, values, onChange }: Props) {
                   return;
                 }
                 // Check if it's a valid number
-                const num = parseFloat(rawValue);
+                const num = Number(rawValue);
                 if (!isNaN(num)) {
                   onChange(field.name, num);
                 }

--- a/app/(core)/components/inputs/NumberInput.jsx
+++ b/app/(core)/components/inputs/NumberInput.jsx
@@ -9,6 +9,13 @@ function NumberInput({
   name,
   step,
 }) {
+  // Convert to string for display, handling all cases
+  let displayValue = "";
+  if (val === "" || val === undefined || val === null) {
+    displayValue = "";
+  } else {
+    displayValue = String(val);
+  }
   return (
     <div className="control-group">
       <label className="input-label" htmlFor={name}>
@@ -18,7 +25,7 @@ function NumberInput({
         type="text"
         inputMode="numeric"
         id={name}
-        value={val === undefined || val === null ? "" : val}
+        value={displayValue}
         min={min}
         max={max}
         step={step || 1}


### PR DESCRIPTION
### Problem
When users click `.` (dot) or `,` (comma) in the number input field, it shows `NaN` instead of handling the input properly.

### What changed in this PR
- Updated onChange handler to filter out invalid characters (`.`, `,`, and other non-numeric inputs)
- Empty inputs now stay empty until user types a valid number

### Before
- User clicks `.` or `,` → input shows `NaN`

### After
- User clicks `.` or `,` → input ignores invalid characters or stays empty
- No NaN values appear

### Testing performed
- [x] Click `.` → no NaN, field stays as is
- [x] Click `,` → no NaN, field stays as is
- [x] Delete all text → field is blank
- [x] Type valid numbers → works normally

### Related
- Previous PR: #260 (merged but incomplete)