### PR TITLE
fix: simplify footer quick links styling

### DIFF
--- a/app/(core)/components/Footer.jsx
+++ b/app/(core)/components/Footer.jsx
@@ -49,19 +49,21 @@ function Footer() {
           </p>
         </div>
         <div className="footer-section footer-links">
-          <h3 className="footer-center">Quick Links</h3>
+          <h3>Quick Links</h3>
           <ul>
             {links.map(({ to, label }) => (
               <li key={to}>
-                <div className="footer-links-dot" />
                 <Link href={to}>{label}</Link>
               </li>
             ))}
             <li>
-              <div className="footer-links-dot" />
-              <a onClick={openFeedback} style={{ cursor: "pointer" }}>
+              <button
+                type="button"
+                className="footer-feedback-link"
+                onClick={openFeedback}
+              >
                 Leave Feedback
-              </a>
+              </button>
             </li>
           </ul>
         </div>

--- a/app/(core)/styles/index.css
+++ b/app/(core)/styles/index.css
@@ -953,45 +953,42 @@ footer {
   padding: 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .footer-links li {
   margin-bottom: 0.5rem;
-  position: relative;
+  width: 100%;
 }
 
-.footer-links li::before {
-  content: "";
-  position: absolute;
-  left: -1.2rem;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 0.7em;
-  height: 0.7em;
-  border-radius: 50%;
-  transition:
-    box-shadow 0.3s,
-    background 0.3s;
+.footer-links h3 {
+  justify-content: flex-start;
+  text-align: left;
 }
 
-.footer-links a {
-  color: var(--accent-color);
+.footer-links a,
+.footer-feedback-link {
+  color: var(--text-color);
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  text-align: left;
   transition:
     color 0.3s,
-    text-shadow 0.3s;
+    text-shadow 0.3s,
+    box-shadow 0.3s;
 }
 
-.footer-links a:hover {
+.footer-links a:hover,
+.footer-feedback-link:hover {
   color: var(--accent-color);
-  text-shadow: 0 0 6px var(--accent-color);
-  box-shadow: 0 0 0px var(--accent-color);
+  text-shadow: none;
+  box-shadow: none;
 }
 
-.footer-links li:hover::before,
-.footer-links a:hover ~ li::before {
-  background: var(--accent-color);
-  box-shadow: 0 0 8px var(--accent-color);
+.footer-feedback-link {
+  cursor: pointer;
 }
 
 .footer-center {


### PR DESCRIPTION
This tightens up the footer quick links so they feel more consistent with the rest of the layout.\n\n- left-aligns the Quick Links heading and list\n- removes the decorative dot indicators\n- keeps the links in the normal theme text color by default\n- limits hover feedback to a simple color change\n- switches the feedback entry to a real button so it behaves like the other quick actions\n\nCloses #263