### PR TITLE
feat: add github badge to header

### DIFF
--- a/app/(core)/components/GitHubHeaderBadge.jsx
+++ b/app/(core)/components/GitHubHeaderBadge.jsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faGithub } from "@fortawesome/free-brands-svg-icons";
+
+const REPO_URL = "https://github.com/physicshub/physicshub.github.io";
+const REPO_API = "https://api.github.com/repos/physicshub/physicshub.github.io";
+const CONTRIBUTORS_API = `${REPO_API}/contributors?per_page=100`;
+
+export default function GitHubHeaderBadge({ mode }) {
+  const [stats, setStats] = useState({ stars: null, contributors: null });
+  const [messageIndex, setMessageIndex] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadStats() {
+      try {
+        const [repoRes, contributorsRes] = await Promise.all([
+          fetch(REPO_API),
+          fetch(CONTRIBUTORS_API),
+        ]);
+
+        const repoData = await repoRes.json();
+        const contributorsData = await contributorsRes.json();
+
+        if (cancelled) return;
+
+        setStats({
+          stars:
+            typeof repoData?.stargazers_count === "number"
+              ? repoData.stargazers_count
+              : null,
+          contributors: Array.isArray(contributorsData)
+            ? contributorsData.length
+            : null,
+        });
+      } catch {
+        if (!cancelled) {
+          setStats({ stars: null, contributors: null });
+        }
+      }
+    }
+
+    loadStats();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const messages = useMemo(
+    () => [
+      stats.stars != null ? `${stats.stars} stars` : "Open source",
+      stats.contributors != null
+        ? `${stats.contributors} contributors`
+        : "Built in public",
+      "Star the repo",
+    ],
+    [stats]
+  );
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setMessageIndex((current) => (current + 1) % messages.length);
+    }, 2600);
+
+    return () => window.clearInterval(intervalId);
+  }, [messages.length]);
+
+  return (
+    <a
+      className={`github-header-badge ${mode === "light" ? "github-header-badge--light" : "github-header-badge--dark"}`}
+      href={REPO_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Open PhysicsHub on GitHub"
+      title="Open PhysicsHub on GitHub"
+    >
+      <FontAwesomeIcon icon={faGithub} className="github-header-badge__icon" />
+      <span className="github-header-badge__viewport" aria-hidden="true">
+        <span
+          className="github-header-badge__track"
+          style={{ transform: `translateY(-${messageIndex * 1.15}rem)` }}
+        >
+          {messages.map((message) => (
+            <span className="github-header-badge__label" key={message}>
+              {message}
+            </span>
+          ))}
+        </span>
+      </span>
+    </a>
+  );
+}

--- a/app/(core)/components/Header.jsx
+++ b/app/(core)/components/Header.jsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import { Logo } from "./Logo";
 import NavMenu from "./Nav";
 import { Theme } from "./Theme";
+import GitHubHeaderBadge from "./GitHubHeaderBadge.jsx";
 import { useSticky } from "../hooks/useSticky";
 import { useTheme } from "../hooks/useTheme";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -46,6 +47,7 @@ export default function Header() {
 
         <div className="controls">
           <GoogleTranslator />
+          <GitHubHeaderBadge mode={mode} />
           <Theme mode={mode} onToggle={toggleMode} />
         </div>
       </div>

--- a/app/(core)/styles/index.css
+++ b/app/(core)/styles/index.css
@@ -190,6 +190,9 @@ header.sticky {
 nav {
   position: relative;
   z-index: 2100;
+  flex: 1;
+  display: flex;
+  justify-content: center;
 }
 
 nav ul {
@@ -238,8 +241,68 @@ nav a:hover::after {
 .controls {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  width: 25%;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  width: auto;
+  flex-shrink: 0;
+}
+
+.github-header-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  height: 2.75rem;
+  min-width: 9.25rem;
+  padding: 0 0.85rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.18);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.github-header-badge:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.24);
+}
+
+.github-header-badge--dark {
+  background: linear-gradient(to top, #020617, #0f172a);
+  color: #f8fafc;
+}
+
+.github-header-badge--light {
+  background: linear-gradient(to top, #f8fafc, #f1f5f9);
+  color: #1c1917;
+}
+
+.github-header-badge__icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.github-header-badge__viewport {
+  position: relative;
+  display: block;
+  height: 1.15rem;
+  overflow: hidden;
+  min-width: 7rem;
+}
+
+.github-header-badge__track {
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.35s ease;
+}
+
+.github-header-badge__label {
+  display: flex;
+  align-items: center;
+  height: 1.15rem;
+  white-space: nowrap;
+  font-size: 0.92rem;
+  font-weight: 600;
 }
 
 .search-container {
@@ -463,6 +526,7 @@ header.open nav ul {
     top: 100%;
     left: 0;
     width: 100%;
+    display: block;
     max-height: 0;
     overflow: hidden;
     transition: max-height 0.4s ease;


### PR DESCRIPTION
This adds a GitHub badge to the desktop header next to the theme switcher so the repo is always visible from the main navigation.

- adds a header badge that links to the repo
- rotates through stars, contributor count, and a short call to action
- matches the theme switcher styling in both light and dark mode
- adjusts the desktop header layout so the new badge fits cleanly

Closes #261