### PR TITLE
chore: add i18n parser config

### DIFF
--- a/i18next-parser.config.cjs
+++ b/i18next-parser.config.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  defaultNamespace: "common",
+  useKeysAsDefaultValue: true,
+  functions: ["t"],
+  locales: ["en", "es", "ar", "fr", "it", "de"],
+  output: "app/(core)/locales/$LOCALE.json",
+  input: ["app/**/*.{js,jsx,ts,tsx}", "!app/(core)/locales/**", "!app/api/**"],
+  sort: true,
+  lexers: {
+    js: ["JsxLexer"],
+    jsx: ["JsxLexer"],
+    ts: ["JavascriptLexer"],
+    tsx: ["JsxLexer"],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "predeploy": "npm run build && npm run contributors",
     "deploy": "gh-pages -d out",
     "generate:sitemap": "node scripts/sitemap-generator.js",
+    "i18n:extract": "npx i18next-parser --config i18next-parser.config.cjs",
     "contributors": "node --loader ts-node/esm scripts/contributors/contributors.ts",
     "lint": "eslint",
     "lint:fix": "eslint --fix",


### PR DESCRIPTION
This wires up the Phase 2 extraction step so the current translation setup has a runnable parser config instead of just issue notes.

- adds an `i18next-parser` config that matches the repo's flat locale file structure
- targets the app sources while excluding the locale files and API routes
- adds an `npm run i18n:extract` script for the one-off extraction step
- uses a `.cjs` config so it works cleanly in this repo's ESM package setup

Closes #248