### PR TITLE
Fix search to support chapter number and labels (closes #284)

### DIFF
--- a/app/(pages)/simulations/page.jsx
+++ b/app/(pages)/simulations/page.jsx
@@ -29,7 +29,6 @@ export default function Simulations() {
   const handleStart = () => {
     localStorage.setItem("hasVisitedSimulations", "true");
     scrollToContent();
-    //setTimeout(() => setShowHero(false), duration);
   };
 
   const scrollToContent = () => {
@@ -60,12 +59,28 @@ export default function Simulations() {
       .trim()
       .split(/\s+/)
       .filter((term) => term.length > 0);
+
     if (searchTerms.length === 0) return true;
+
     const chapterTagNames = getChapterTagNames(chap.tags);
+
     return searchTerms.every((term) => {
+      const normalizedTerm = term.replace(/\s+/g, "");
+
       const matchesName = chap.name.toLowerCase().includes(term);
+
       const matchesTag = chapterTagNames.includes(term);
-      return matchesName || matchesTag;
+
+      const matchesChapterNumber = chap.id && chap.id.toString().includes(term);
+
+      const matchesChapterLabel =
+        chap.id &&
+        (`chapter${chap.id}`.includes(normalizedTerm) ||
+          `ch${chap.id}`.includes(normalizedTerm));
+
+      return (
+        matchesName || matchesTag || matchesChapterNumber || matchesChapterLabel
+      );
     });
   });
 
@@ -73,7 +88,6 @@ export default function Simulations() {
     <div
       className={`simulations-container ${isCompleted ? "notranslate" : ""}`}
     >
-      {/* RENDERING CONDIZIONALE DELLA HERO */}
       {showHero && (
         <section className="simulations-hero">
           <h1>{t("Interactive Physics Simulations")}</h1>


### PR DESCRIPTION
This PR implements the feature requested in #284 by extending the simulations search functionality.

Added support for searching by:
Chapter number (e.g., 1)
Chapter labels (e.g., chapter 1, chapter1, ch 1)
Preserved existing search behavior (name and tags)

So now users can now find simulations using either the title or the chapter reference.
<img width="1918" height="831" alt="Screenshot 2026-04-21 173343" src="https://github.com/user-attachments/assets/89c6632e-f311-44f5-bd9a-a80eed2e6953" />
<img width="1917" height="838" alt="Screenshot 2026-04-21 173407" src="https://github.com/user-attachments/assets/e8a53c38-2f45-4b7d-b761-43d63d5b19fc" />
