### PR TITLE
fix: improve sitemap.xml for better Google Search Console compatibility

### DIFF
--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -110,7 +110,9 @@ async function generateSitemap() {
   console.log("\n📋 Sitemap Summary:");
   console.log(`   - Total URLs: ${allRoutes.length}`);
   console.log(`   - Lastmod date: ${currentDate}`);
-  console.log(`   - Unused namespaces removed for better crawler compatibility`);
+  console.log(
+    `   - Unused namespaces removed for better crawler compatibility`,
+  );
 }
 
 generateSitemap().catch((err) => {

--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -1,25 +1,36 @@
 // sitemap-generator.js
 import { SitemapStream, streamToPromise } from "sitemap";
-import { writeFileSync } from "fs";
+import { writeFileSync, existsSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import xmlFormat from "xml-formatter";
 
 import { routes as staticRoutes } from "../routes.js";
 import { blogsArray } from "../app/(core)/data/articles/index.js";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 const hostname = "https://physicshub.github.io";
 const sitemapName = "sitemap";
 
+// Current date in W3C format (YYYY-MM-DD) for lastmod
+const getCurrentDate = () => new Date().toISOString().split("T")[0];
+
 function updateRoutesFile(allRoutes) {
   const content = `export const routes = ${JSON.stringify(allRoutes, null, 2)};`;
-  writeFileSync("../routes.js", content);
+  writeFileSync(join(__dirname, "../routes.js"), content);
   console.log("✅ routes.js physical file updated!");
 }
 
 async function generateSitemap() {
+  const currentDate = getCurrentDate();
+
   const blogRoutes = blogsArray.map((blog) => ({
     path: `/blog/${blog.slug}`,
     changefreq: "monthly",
     priority: 0.8,
+    lastmod: currentDate,
   }));
 
   const combinedRoutes = [...staticRoutes, ...blogRoutes];
@@ -31,56 +42,78 @@ async function generateSitemap() {
   });
   const allRoutes = Array.from(uniqueRoutesMap.values());
 
-  const sitemap = new SitemapStream({ hostname });
+  // Generate sitemap with only the required namespace
+  // Removing unused news, xhtml, image, video namespaces that can confuse crawlers
+  const sitemap = new SitemapStream({
+    hostname,
+    xmlns: {
+      news: false,
+      xhtml: false,
+      image: false,
+      video: false,
+    },
+  });
 
   allRoutes.forEach((route) => {
     sitemap.write({
       url: route.path,
       changefreq: route.changefreq,
       priority: route.priority,
+      lastmod: route.lastmod || currentDate,
     });
   });
 
   sitemap.end();
 
   const rawXml = (await streamToPromise(sitemap)).toString();
+
+  // Add XML declaration and format
   const formatted = xmlFormat(rawXml, {
     indentation: "  ",
     collapseContent: true,
+    lineSeparator: "\n",
   });
 
-  writeFileSync(`./public/${sitemapName}.xml`, formatted);
-  console.log(`✅ Sitemap generated with ${allRoutes.length} links!`);
+  const xmlOutput = `<?xml version="1.0" encoding="UTF-8"?>\n${formatted}`;
+
+  // Ensure public directory exists
+  const publicDir = join(__dirname, "../public");
+  if (!existsSync(publicDir)) {
+    mkdirSync(publicDir, { recursive: true });
+  }
+
+  // Write to public directory
+  const publicPath = join(publicDir, `${sitemapName}.xml`);
+  writeFileSync(publicPath, xmlOutput);
+  console.log(`✅ Sitemap generated with ${allRoutes.length} links in public/`);
 
   // Also write to out/ if it exists (for deployment consistency)
-  try {
-    const fs = await import("fs");
-    if (fs.existsSync("./out")) {
-      writeFileSync(`./out/${sitemapName}.xml`, formatted);
-      console.log(`✅ Sitemap copied to ./out!`);
-    }
-  } catch (e) {
-    console.error("Error writing to out directory:", e);
+  const outDir = join(__dirname, "../out");
+  if (existsSync(outDir)) {
+    writeFileSync(join(outDir, `${sitemapName}.xml`), xmlOutput);
+    console.log(`✅ Sitemap copied to ./out/`);
   }
 
-  // Robots.txt
+  // Generate robots.txt with sitemap reference
   const robotsTxt =
     `User-agent: *\nAllow: /\n\nSitemap: ${hostname}/${sitemapName}.xml`.trim();
-  writeFileSync("./public/robots.txt", robotsTxt);
 
-  try {
-    const fs = await import("fs");
-    if (fs.existsSync("./out")) {
-      writeFileSync("./out/robots.txt", robotsTxt);
-      console.log(`✅ Robots.txt copied to ./out!`);
-    }
-  } catch (e) {
-    console.error("Error writing robots.txt to out directory:", e);
+  writeFileSync(join(publicDir, "robots.txt"), robotsTxt);
+  console.log("✅ robots.txt updated in public/");
+
+  if (existsSync(outDir)) {
+    writeFileSync(join(outDir, "robots.txt"), robotsTxt);
+    console.log("✅ robots.txt copied to ./out/");
   }
 
-  console.log("✅ Robots.txt updated!");
-
   updateRoutesFile(allRoutes);
+  console.log("\n📋 Sitemap Summary:");
+  console.log(`   - Total URLs: ${allRoutes.length}`);
+  console.log(`   - Lastmod date: ${currentDate}`);
+  console.log(`   - Unused namespaces removed for better crawler compatibility`);
 }
 
-generateSitemap();
+generateSitemap().catch((err) => {
+  console.error("❌ Error generating sitemap:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
This PR fixes the sitemap.xml generation to improve compatibility with Google Search Console (fixes #107).

## Problem
Google Search Console was showing "Impossible to recover" when trying to index the sitemap at `https://physicshub.github.io/sitemap.xml`.

## Changes Made
- **Added `<lastmod>` dates** to all URLs - Google strongly recommends this for better crawl scheduling
- **Removed unused XML namespaces** (`news`, `xhtml`, `image`, `video`) that were declared but never used - these can confuse some crawlers
- **Added proper error handling** - `process.exit(1)` on failure so build fails visibly if sitemap generation fails
- **Used `path.join()`** for cross-platform directory path handling
- **Added debug summary** output showing total URLs, lastmod date, and namespace status
- **Ensured public directory exists** before writing files (defensive coding)

## Test Plan
1. Run `npm run generate:sitemap`
2. Check generated `public/sitemap.xml` contains `<lastmod>` entries
3. Verify only the core sitemap namespace is present
4. Deploy and test with Google Search Console's "Live Test" feature

## Files Changed
- `scripts/sitemap-generator.js`

## Checklist
- [x] Added `<lastmod>` dates to all URL entries
- [x] Removed unused XML namespace declarations
- [x] Added error handling for build-time failures
- [x] Maintains backward compatibility with existing routes
- [x] No breaking changes to output format