### PR TITLE
Fixed Bug #291 : Input Field Accepts Empty Values After Blur 

### DIFF
--- a/app/(core)/components/inputs/DynamicInputs.tsx
+++ b/app/(core)/components/inputs/DynamicInputs.tsx
@@ -3,6 +3,7 @@ import CheckboxInput from "./CheckboxInput.jsx";
 import ColorInput from "./ColorInput.jsx";
 import SelectInput from "./SelectInput.jsx";
 import useTranslation from "../../hooks/useTranslation.ts";
+import { useState } from "react";
 
 interface FieldConfig {
   name: string;
@@ -24,6 +25,9 @@ interface Props {
 export default function DynamicInputs({ config, values, onChange }: Props) {
   const { t, meta } = useTranslation();
   const isCompleted = meta?.completed || false;
+  const [lastValidValues, setLastValidValues] =
+    useState<Record<string, string | number | boolean>>(values);
+
   return (
     <div className={`inputs-container ${isCompleted ? "notranslate" : ""}`}>
       {config.map((field) => {
@@ -63,23 +67,33 @@ export default function DynamicInputs({ config, values, onChange }: Props) {
                 }
                 // Only validate, don't convert to number yet
                 const isValidNumber = /^\d*\.?\d*$/.test(rawValue);
-
                 if (isValidNumber) {
                   // Store as string to preserve formatting like "5.0"
                   onChange(field.name, rawValue);
                 }
               }}
               onBlur={() => {
-                const currentValue = val;
+                const currentValue = values[field.name];
+
                 if (
                   typeof currentValue === "string" &&
                   currentValue !== "" &&
                   currentValue !== "."
                 ) {
                   const num = Number(currentValue);
+
                   if (!isNaN(num)) {
-                    onChange(field.name, num);
+                    const newValue = num;
+                    onChange(field.name, newValue);
+                    //commit as last valid value
+                    setLastValidValues((prev) => ({
+                      ...prev,
+                      [field.name]: newValue,
+                    }));
                   }
+                } else {
+                  //revert if invalid
+                  onChange(field.name, lastValidValues[field.name]);
                 }
               }}
             />


### PR DESCRIPTION
## 🔍 Description

Fixes input field validation issue where empty or invalid numeric inputs were incorrectly accepted after blur, causing empty fields and incorrect simulation values.

Previously, clearing a number input  would incorrectly update the simulation state and the UI . 
This PR introduces proper handling of intermediate typing states and restores the last valid value when needed.

Closes #291

---

## ✅ Checklist

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [x] Implemented correct handling of invalid intermediate inputs (`""`, `"."`, etc.)
- [x] Added restoration of last valid value on blur
- [x] Verified numeric input behavior across edge cases
- [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

---

## 🎨 Visual Changes

- No major visual UI changes
- Improved input behavior and stability for number fields
- Smoother typing experience with corrected validation logic

---

## 📂 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---

## 🧩 Additional Notes for Reviewers

This change improves controlled numeric input handling:

- Prevents invalid values from entering simulation state
- Allows natural typing behavior (e.g. "12.")
- Ensures only valid numeric values are stored for simulation
- Restores last valid value when input becomes empty or invalid on blur

Handled edge cases:
- Empty string input (`""`)
- Lone decimal point (`"."`)
- Invalid numeric strings (`"abc"`, `"12..3"`)
- Proper fallback to last valid value