### PR TITLE
fix: correct drag coefficient label and units in ParabolicMotion

### DIFF
--- a/app/(core)/data/configs/ParabolicMotion.js
+++ b/app/(core)/data/configs/ParabolicMotion.js
@@ -66,7 +66,7 @@ export const INPUT_FIELDS = [
   },
   {
     name: "dragCoeff",
-    label: "c_d - Linear drag (1/s):",
+    label: "c_d - Quadratic drag (kg/m):",
     type: "number",
     placeholder: "Insert drag coeff...",
     min: 0,


### PR DESCRIPTION
# 📘 Pull Request Template – PhysicsHub

Thank you for contributing to **PhysicsHub**!  
Please complete the sections below to help us review your pull request efficiently.

---

## 🔍 Description

  The drag input was labeled "Linear drag (1/s)" but the simulation calls               
  airResistance() with quadratic drag. This mislabels the physical quantity and gives     
  students the wrong units. Updated the label to "Quadratic drag (kg/m)" to match the     
  actual computation.

Closes #BUG-010 (if applicable)

---

## ✅ Checklist

Before requesting a review, please ensure that you have:

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [x] Updated documentation, comments, or in-code explanations where needed
- [x] Verified responsiveness across devices (desktop, tablet, mobile)
- [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

---

## 🎨 Visual Changes (if UI-related)

IF CHANGES ARE RELATED TO SIMULATIONS PLEASE SEND A SHORT CLIP ABOUT IT
(OBLIGATORY)

<!-- Attach screenshots, GIFs, or screen recordings to illustrate UI/UX changes. -->

---

## 📂 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code quality improvement
- [ ] 🎨 UI/UX enhancement
- [ ] 🔒 Security improvement

---

## 🧩 Additional Notes for Reviewers

<!-- Highlight specific areas that need attention, potential edge cases, or architectural decisions. -->
