### PR TITLE
fix: repair broken image urls in blog articles

### DIFF
--- a/app/(core)/components/theory/elements/TheoryImage.tsx
+++ b/app/(core)/components/theory/elements/TheoryImage.tsx
@@ -5,7 +5,7 @@ import { faCopyright, faUpload } from "@fortawesome/free-solid-svg-icons";
 import { EditableProps } from "../types";
 import Image from "next/image";
 
-type ImageSize = "small" | "medium" | "large" | "full";
+type ImageSize = "xsmall" | "small" | "medium" | "large" | "full";
 
 interface TheoryImageProps extends EditableProps {
   src: string;
@@ -65,6 +65,7 @@ export const TheoryImage: React.FC<TheoryImageProps> = ({
             onChange={handleSizeChange}
             className="size-select"
           >
+            <option value="xsmall">{t("Extra Small")}</option>
             <option value="small">{t("Small")}</option>
             <option value="medium">{t("Medium")}</option>
             <option value="large">{t("Large")}</option>

--- a/app/(core)/components/theory/types.ts
+++ b/app/(core)/components/theory/types.ts
@@ -21,7 +21,7 @@ export interface Children {
   children?: React.ReactNode;
 }
 
-export type ImageSize = "small" | "medium" | "large" | "full";
+export type ImageSize = "xsmall" | "small" | "medium" | "large" | "full";
 
 export interface BlockData {
   type: string;

--- a/app/(core)/data/articles/class-12-physics.js
+++ b/app/(core)/data/articles/class-12-physics.js
@@ -155,7 +155,7 @@ export const class12PhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Dipole_field.svg/600px-Dipole_field.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Dipole_field.svg",
             alt: "Electric field lines of an electric dipole.",
             caption:
               "Electric field lines of a dipole. Lines emerge from the positive charge and converge into the negative charge, showing the characteristic dipole pattern.",
@@ -306,7 +306,7 @@ export const class12PhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/10/Ohm%27s_Law_with_Voltage_source_TeX.svg/600px-Ohm%27s_Law_with_Voltage_source_TeX.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Ohm%27s_Law_with_Voltage_source_TeX.svg",
             alt: "Simple Ohm's Law circuit diagram with battery, resistor and labels.",
             caption:
               "A basic Ohm's Law circuit: a voltage source V drives current I through resistance R. The relationship V = IR is the cornerstone of circuit analysis.",
@@ -616,12 +616,12 @@ export const class12PhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/16/RLC_series_circuit_v1.svg/600px-RLC_series_circuit_v1.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/RLC_series_circuit_v1.svg",
             alt: "Series RLC circuit diagram showing resistor, inductor, capacitor in series with AC source.",
             caption:
               "A series RLC circuit. At resonance the inductive and capacitive reactances cancel, giving minimum impedance and maximum current.",
             href: "https://en.wikipedia.org/wiki/RLC_circuit",
-            size: "medium",
+            size: "small",
           },
           {
             type: "paragraph",
@@ -682,7 +682,7 @@ export const class12PhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/99/EM-Wave.gif/300px-EM-Wave.gif",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/EM-Wave.gif",
             alt: "Animation of an electromagnetic wave showing perpendicular E and B fields.",
             caption:
               "An electromagnetic wave: the electric field (E, blue) and magnetic field (B, red) oscillate perpendicular to each other and to the direction of propagation.",
@@ -854,7 +854,7 @@ export const class12PhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Single_slit_and_double_slit2.jpg/600px-Single_slit_and_double_slit2.jpg",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Single_slit_and_double_slit2.jpg",
             alt: "Photograph of single-slit and double-slit diffraction patterns on a screen.",
             caption:
               "Double-slit interference pattern (bottom): evenly spaced bright fringes modulated by the single-slit diffraction envelope (top). The central maximum is brightest.",
@@ -1017,7 +1017,7 @@ export const class12PhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Hydrogen_transitions.svg/600px-Hydrogen_transitions.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Hydrogen_transitions.svg",
             alt: "Energy level diagram of hydrogen atom showing Lyman, Balmer and Paschen series transitions.",
             caption:
               "Energy levels of the hydrogen atom. Electron transitions between levels emit photons of specific energies, producing the characteristic emission spectrum. The Balmer series (transitions to n=2) falls in the visible range.",
@@ -1116,7 +1116,7 @@ export const class12PhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/PN_diode_with_electrical_symbol.svg/600px-PN_diode_with_electrical_symbol.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/PN_diode_with_electrical_symbol.svg",
             alt: "Diagram of a p-n junction diode with circuit symbol showing depletion region.",
             caption:
               "A p-n junction diode. The depletion region acts as a barrier. Forward bias reduces this barrier; reverse bias increases it, giving the diode its one-way current property.",

--- a/app/(core)/data/articles/physics-behind-three-body-problem.js
+++ b/app/(core)/data/articles/physics-behind-three-body-problem.js
@@ -41,7 +41,7 @@ export const threeBodyProblemBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/1/1c/Three-body_Problem_Animation_with_COM.gif",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Three-body_Problem_Animation_with_COM.gif",
             alt: "Animation of the figure-eight three-body orbit solution showing three equal masses chasing each other.",
             caption:
               "The famous figure-eight solution: three equal masses chasing each other in a perfect figure-eight orbit. This is one of only a handful of stable, periodic solutions ever found to the three-body problem — and it took until 1993 to discover it.",
@@ -174,7 +174,7 @@ export const threeBodyProblemBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f4/PSM_V82_D416_Henri_Poincare.png/500px-PSM_V82_D416_Henri_Poincare.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/PSM_V82_D416_Henri_Poincare.png",
             alt: "Portrait photograph of Henri Poincaré, the French mathematician who discovered chaos in the three-body problem.",
             caption:
               "Henri Poincaré (1854–1912). His 1890 paper on the three-body problem contained the first rigorous description of chaotic dynamics in a deterministic system — a discovery so disturbing that he tried to suppress it.",
@@ -242,7 +242,7 @@ export const threeBodyProblemBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Lagrange_points_simple.svg/960px-Lagrange_points_simple.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Lagrange_points_simple.svg",
             alt: "Diagram showing the five Lagrange points of the Sun-Earth system including the stable L4 and L5 equilateral triangle positions.",
             caption:
               "The five Lagrange points of a two-body system. L4 and L5 (the equilateral-triangle points) are stable — objects placed there naturally stay. L1, L2, L3 are unstable saddle points. The James Webb Space Telescope orbits the Sun-Earth L2 point.",
@@ -524,7 +524,7 @@ export const threeBodyProblemBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/Hydra%2C_Nix%2C_Styx_conjunctions_cycle.png/1280px-Hydra%2C_Nix%2C_Styx_conjunctions_cycle.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Hydra%2C_Nix%2C_Styx_conjunctions_cycle.png",
             alt: "Animation of the Galilean moons Io, Europa, and Ganymede showing the Laplace orbital resonance.",
             caption:
               "The Laplace resonance of Jupiter's moons: Io (innermost), Europa (middle), and Ganymede (outermost) orbit in a precise 4:2:1 ratio. This three-body gravitational resonance has lasted billions of years and drives Io's extreme volcanism.",
@@ -737,7 +737,7 @@ export const threeBodyProblemBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/LIGO_measurement_of_gravitational_waves.svg/960px-LIGO_measurement_of_gravitational_waves.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/LIGO_measurement_of_gravitational_waves.svg",
             alt: "Graph of the LIGO gravitational wave signal from the first binary black hole merger detection GW150914.",
             caption:
               "The first gravitational wave detection by LIGO in 2015 (GW150914): two black holes merging, 1.3 billion light-years away. Three-body scattering in dense stellar clusters is one of the leading mechanisms for creating such tight black hole binaries in the first place.",

--- a/app/(core)/data/articles/physics-of-pendulum-explained.js
+++ b/app/(core)/data/articles/physics-of-pendulum-explained.js
@@ -34,11 +34,11 @@ export const pendulumBlog = {
           },
           {
             type: "image",
-            src: "https://www.school-for-champions.com/science/images/pendulum_period_small_angle.gif",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Pendulum_animation.gif",
             alt: "Animated diagram showing a simple pendulum's back-and-forth motion with labeled components.",
             caption:
               "The fundamental geometry of simple pendulum motion, illustrating the bob's trajectory, the restoring arc, and the angular displacement from equilibrium.",
-            href: "https://www.school-for-champions.com/science/pendulum_period.htm",
+            href: "https://en.wikipedia.org/wiki/Pendulum",
             size: "medium",
           },
           {
@@ -104,7 +104,7 @@ export const pendulumBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/b/b2/Simple_gravity_pendulum.svg",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Simple_gravity_pendulum.svg",
             alt: "Free body diagram showing force vectors on a pendulum bob at maximum displacement.",
             caption:
               "Force decomposition diagram illustrating gravitational components, tension, and the net restoring force tangent to the circular arc. The tangential component $F_t = -mg\\sin\\theta$ drives the oscillation.",
@@ -296,10 +296,10 @@ export const pendulumBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Pendulum_energy_graph.svg/800px-Pendulum_energy_graph.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Energy_in_SHM.gif",
             alt: "Graph showing kinetic and potential energy curves over one complete pendulum cycle.",
             caption:
-              "Energy transformation diagram: potential energy (blue) peaks at maximum displacement while kinetic energy (red) peaks at equilibrium. Their sum (green) remains constant, demonstrating mechanical energy conservation.",
+              "Energy transformation diagram: potential energy (red) peaks at maximum displacement while kinetic energy (blue) peaks at equilibrium. Their sum (black) remains constant, demonstrating mechanical energy conservation.",
             href: "https://en.wikipedia.org/wiki/Pendulum",
             size: "large",
           },
@@ -443,12 +443,12 @@ export const pendulumBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/Pendulum_phase_portrait.svg/600px-Pendulum_phase_portrait.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Pendulum_phase_portrait.svg",
             alt: "Phase portrait showing oscillatory trajectories inside the separatrix and rotational trajectories outside.",
             caption:
               "Complete phase portrait of the nonlinear pendulum. Inner closed orbits represent oscillations; the figure-eight separatrix (red) divides oscillatory from rotational regimes; outer waves represent continuous rotations.",
             href: "https://en.wikipedia.org/wiki/Pendulum_(mechanics)",
-            size: "large",
+            size: "medium",
           },
           {
             type: "paragraph",
@@ -760,7 +760,7 @@ export const pendulumBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/4/45/Double-compound-pendulum.gif",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Double-compound-pendulum.gif",
             alt: "Animation of double pendulum motion showing chaotic trajectory.",
             caption:
               "Chaotic motion of a double pendulum. The lower bob traces an intricate, non-repeating path. Two simulations with nearly identical initial conditions diverge rapidly, illustrating sensitivity to initial conditions.",

--- a/app/(core)/data/articles/projectile-parabolic-motion.js
+++ b/app/(core)/data/articles/projectile-parabolic-motion.js
@@ -3,7 +3,7 @@ import TAGS from "../tags.js";
 export const projectileParabolicBlog = {
   id: "bb-007",
   slug: "projectile-parabolic-motion",
-  name: "how parabolic projectile motion works?",
+  name: "How parabolic projectile motion works?",
   desc: "Understand parabolic projectile motion in easy way.",
   tags: [TAGS.MEDIUM, TAGS.PHYSICS, TAGS.GRAVITY, TAGS.ACCELERATION],
   theory: {

--- a/app/(core)/data/articles/spring-connection.js
+++ b/app/(core)/data/articles/spring-connection.js
@@ -3,7 +3,7 @@ import TAGS from "../tags.js";
 export const springConnectionBlog = {
   id: "bb-005",
   slug: "spring-connection",
-  name: "How works a spring?",
+  name: "How does a Spring work?",
   desc: "All you need to know about springs.",
   tags: [TAGS.ADVANCED, TAGS.PHYSICS, TAGS.OSCILLATIONS, TAGS.SPRINGS],
   theory: {

--- a/app/(core)/data/articles/what-is-physics.js
+++ b/app/(core)/data/articles/what-is-physics.js
@@ -34,12 +34,12 @@ export const whatIsPhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Physics_and_other_sciences.png/640px-Physics_and_other_sciences.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Physics_and_other_sciences.png",
             alt: "Diagram showing physics as the foundation of all natural sciences.",
             caption:
               "Physics sits at the foundation of all natural sciences. Chemistry, biology, and engineering all depend on physical laws — making physics the most fundamental experimental science.",
             href: "https://en.wikipedia.org/wiki/Physics",
-            size: "large",
+            size: "xsmall",
           },
           {
             type: "callout",
@@ -109,12 +109,12 @@ export const whatIsPhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f5/GodfreyKneller-IsaacNewton-1689.jpg/440px-GodfreyKneller-IsaacNewton-1689.jpg",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/GodfreyKneller-IsaacNewton-1689.jpg",
             alt: "Portrait of Isaac Newton, the father of classical mechanics.",
             caption:
               "Isaac Newton (1643–1727), whose three laws of motion and law of universal gravitation unified earthly and celestial mechanics into a single mathematical framework — one of the greatest intellectual achievements in history.",
             href: "https://en.wikipedia.org/wiki/Isaac_Newton",
-            size: "medium",
+            size: "small",
           },
           {
             type: "paragraph",
@@ -342,12 +342,12 @@ export const whatIsPhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Sine_wave_amplitude.svg/640px-Sine_wave_amplitude.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Sine_wave_amplitude.svg",
             alt: "Diagram of a sine wave showing amplitude, wavelength, and frequency.",
             caption:
               "A wave is characterized by its wavelength $\\lambda$ (distance between peaks), frequency $f$ (cycles per second), amplitude (peak height), and speed $v = f\\lambda$. These parameters describe everything from ocean swells to gamma rays.",
             href: "https://en.wikipedia.org/wiki/Wave",
-            size: "medium",
+            size: "large",
           },
         ],
       },
@@ -442,12 +442,12 @@ export const whatIsPhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c0/Double_slit_interference.svg/640px-Double_slit_interference.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Double_slit_interference.png",
             alt: "Diagram of the double-slit experiment showing wave interference from particles.",
             caption:
               "The double-slit experiment — often called 'the most beautiful experiment in physics.' A single electron fired at a double slit creates an interference pattern on the detector, as though it passed through both slits simultaneously as a wave. This result demolished classical intuitions about the nature of matter.",
             href: "https://en.wikipedia.org/wiki/Double-slit_experiment",
-            size: "large",
+            size: "medium",
           },
           {
             type: "subtitle",
@@ -535,7 +535,7 @@ export const whatIsPhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/GPS_Satellite_NASA_art-iif.jpg/640px-GPS_Satellite_NASA_art-iif.jpg",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/GPS_Satellite_NASA_art-iif.jpg",
             alt: "GPS satellite orbiting Earth in space.",
             caption:
               "GPS satellites must correct for both Special and General Relativistic time dilation to provide accurate positioning. Without Einstein's theories of relativity — developed 60 years before GPS — modern navigation would be impossible.",
@@ -717,7 +717,7 @@ export const whatIsPhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/The_Scientific_Method.svg/600px-The_Scientific_Method.svg.png",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/The_Scientific_Method.svg",
             alt: "Diagram showing the cyclical steps of the scientific method.",
             caption:
               "The scientific method is cyclical, not linear. Experiments refine theories; theories guide experiments. A theory that fails a precise experimental test must be revised or replaced — even if it has worked for centuries.",
@@ -906,12 +906,12 @@ export const whatIsPhysicsBlog = {
           },
           {
             type: "image",
-            src: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Milky_Way_Night_Sky_Black_Rock_Desert_Nevada.jpg/640px-Milky_Way_Night_Sky_Black_Rock_Desert_Nevada.jpg",
+            src: "https://commons.wikimedia.org/wiki/Special:FilePath/Milky_Way_Night_Sky_Black_Rock_Desert_Nevada.jpg",
             alt: "The Milky Way galaxy visible in a dark night sky over a desert landscape.",
             caption:
               "The Milky Way: 200–400 billion stars, each a nuclear furnace forging elements that will one day become planets, life, and eventually conscious beings that look up and wonder. Physics is the attempt to understand how all of this is possible.",
             href: "https://en.wikipedia.org/wiki/Milky_Way",
-            size: "large",
+            size: "small",
           },
           {
             type: "callout",

--- a/app/(core)/styles/theory.css
+++ b/app/(core)/styles/theory.css
@@ -361,6 +361,10 @@
 }
 
 /* Gestione Dimensioni Responsive */
+.size-xsmall {
+  width: 20%;
+  min-width: 180px;
+}
 .size-small {
   width: 30%;
   min-width: 250px;


### PR DESCRIPTION
## 🔍 Description
- Replaced broken and outdated Wikimedia thumbnail URLs with robust Special:FilePath links to resolve 400 Bad Request errors.
- Added the xsmall image size option and applied it where needed for layout consistency.
- Minor title tweaks to keep layouts consistent.

## ✅ Checklist

Before requesting a review, please ensure that you have:

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [x] Updated documentation, comments, or in-code explanations where needed
- [x] Verified responsiveness across devices (desktop, tablet, mobile)
- [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

---

## 🎨 Visual Changes (if UI-related)
-  High Res SVGs replacing broken thumbnail routing 
<img width="1881" height="825" alt="image" src="https://github.com/user-attachments/assets/0826107f-6589-42df-bc48-d88cf18c1b60" />

---

## 📂 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code quality improvement
- [x] 🎨 UI/UX enhancement
- [ ] 🔒 Security improvement

---

## 🧩 Additional Notes for Reviewers

- The previous implementation relied on hardcoded Wikimedia thumbnail dimensions in the URL string (e.g., .../640px-image.jpg).    By migrating to the Special:FilePath/Image_Name.ext routing, we allow Wikimedia to handle the file delivery dynamically, ensuring the images load reliably

<!-- Highlight specific areas that need attention, potential edge cases, or architectural decisions. -->
