### PR TITLE
fix: show correct unit for acceleration vector label in BallAcceleration

### DIFF
--- a/app/(core)/physics/ForceRenderer.js
+++ b/app/(core)/physics/ForceRenderer.js
@@ -110,7 +110,8 @@ export class ForceRenderer {
 
     let labelText = text;
     if (showMag && magnitude !== undefined) {
-      labelText = `${text} (${magnitude.toFixed(1)}N)`;
+      const unit = options.unit ?? "N";
+      labelText = `${text} (${magnitude.toFixed(1)}${unit})`;
     }
 
     p.push();

--- a/simulations/BallAcceleration.jsx
+++ b/simulations/BallAcceleration.jsx
@@ -222,7 +222,8 @@ export default function BallAcceleration() {
             accelerationForce.x / bodyRef.current.params.mass,
             -(accelerationForce.y / bodyRef.current.params.mass),
             "#ef4444",
-            "Acceleration"
+            "Acceleration",
+            { unit: "m/s²" }
           );
         }
 


### PR DESCRIPTION

# 📘 Pull Request Template – PhysicsHub

Thank you for contributing to **PhysicsHub**!  
Please complete the sections below to help us review your pull request efficiently.

---

## 🔍 Description

The drawLabel method in ForceRenderer hardcoded "N" (Newtons) as the unit suffix for all vectors. In BallAcceleration, the acceleration vector is drawn with F/m values (m/s²), so the label incorrectly displayed "Acceleration (X.XN)".

Added a `unit` option to drawLabel so callers can override the default "N". BallAcceleration now passes `{ unit: "m/s²" }` to drawVector, fixing the label to correctly show "Acceleration (X.Xm/s²)".

Closes #BUG-016(if applicable)

---

## ✅ Checklist

Before requesting a review, please ensure that you have:

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [x] Updated documentation, comments, or in-code explanations where needed
- [x] Verified responsiveness across devices (desktop, tablet, mobile)
- [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

---

## 🎨 Visual Changes (if UI-related)

IF CHANGES ARE RELATED TO SIMULATIONS PLEASE SEND A SHORT CLIP ABOUT IT
(OBLIGATORY)

<!-- Attach screenshots, GIFs, or screen recordings to illustrate UI/UX changes. -->

---

## 📂 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code quality improvement
- [ ] 🎨 UI/UX enhancement
- [ ] 🔒 Security improvement

---

## 🧩 Additional Notes for Reviewers

<!-- Highlight specific areas that need attention, potential edge cases, or architectural decisions. -->
