### PR TITLE
feat: add simulation step controls

### DIFF
--- a/app/(core)/components/Controls.jsx
+++ b/app/(core)/components/Controls.jsx
@@ -9,6 +9,7 @@ import DownloadButton from "./controls/DownloadButton.jsx";
 import UploadButton from "./controls/UploadButton.jsx";
 import ShareLinkControl from "./controls/ShareLinkControl.jsx";
 import EmbedCodeControl from "./controls/EmbedCodeControl.jsx";
+import StepButton from "./controls/StepButton.jsx";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowDown, faArrowUp } from "@fortawesome/free-solid-svg-icons";
@@ -27,7 +28,9 @@ export default function Controls({ onReset, inputs, simulation, onLoad }) {
     >
       <div className="main-controls-wrapper">
         <SpeedControl />
+        <StepButton direction="backward" />
         <PlayPauseButton />
+        <StepButton direction="forward" />
         <ResetButton onReset={onReset} />
 
         <button

--- a/app/(core)/components/controls/StepButton.jsx
+++ b/app/(core)/components/controls/StepButton.jsx
@@ -1,0 +1,27 @@
+import { stepSimulation } from "../../constants/Time.js";
+import useTranslation from "../../hooks/useTranslation.ts";
+
+const STEP_DELTA = 0.01;
+
+export default function StepButton({ direction }) {
+  const { t, meta } = useTranslation();
+  const isCompleted = meta?.completed || false;
+
+  const delta = direction === "backward" ? -STEP_DELTA : STEP_DELTA;
+  const label = direction === "backward" ? "−0.01" : "+0.01";
+  const title =
+    direction === "backward"
+      ? t("Step backward simulation")
+      : t("Step forward simulation");
+
+  return (
+    <button
+      onClick={() => stepSimulation(delta)}
+      className={`btn-glow ${isCompleted ? "notranslate" : ""}`}
+      title={title}
+      aria-label={title}
+    >
+      {label}
+    </button>
+  );
+}

--- a/app/(core)/constants/Time.js
+++ b/app/(core)/constants/Time.js
@@ -1,6 +1,7 @@
 // constants/Time.js
 let timeScale = 1;
 let paused = false;
+let manualStepDelta = 0;
 let simulationInstances = new Map(); // Mappa per tenere traccia di ogni istanza
 
 /**
@@ -8,6 +9,11 @@ let simulationInstances = new Map(); // Mappa per tenere traccia di ogni istanza
  * Uses p.millis() to compute real delta.
  */
 export function computeDelta(p) {
+  if (manualStepDelta !== 0) {
+    const dt = manualStepDelta;
+    manualStepDelta = 0;
+    return dt;
+  }
   if (paused) return 0;
 
   const now = p.millis();
@@ -49,6 +55,12 @@ export function setPause(value) {
   if (paused) {
     simulationInstances.clear();
   }
+}
+
+export function stepSimulation(delta) {
+  if (!paused) return;
+
+  manualStepDelta += delta;
 }
 
 export function resetTime() {

--- a/app/(core)/physics/InclinedPlaneBody.js
+++ b/app/(core)/physics/InclinedPlaneBody.js
@@ -25,7 +25,7 @@ export class InclinedPlaneBody extends PhysicsBody {
    * Physics step constrained to plane
    */
   stepAlongPlane(dt, netForceParallel, angleRad = 0) {
-    if (dt <= 0) return;
+    if (dt === 0) return;
 
     // Calculate acceleration from net force
     this.planeState.accAlongPlane = netForceParallel / this.params.mass;

--- a/app/(core)/physics/PhysicsBody.js
+++ b/app/(core)/physics/PhysicsBody.js
@@ -79,7 +79,7 @@ export class PhysicsBody {
    * ALL CALCULATIONS IN PHYSICS COORDS (Y-UP)
    */
   step(dt) {
-    if (dt <= 0) return;
+    if (dt === 0) return;
 
     // Linear motion
     this.state.velocity.add(
@@ -111,7 +111,7 @@ export class PhysicsBody {
    * Update physics - Verlet integration (more stable for constraints)
    */
   stepVerlet(dt, previousPosition) {
-    if (dt <= 0) return;
+    if (dt === 0) return;
 
     const currentPos = this.state.position.copy();
     const prevPos = previousPosition || this.state.position.copy();

--- a/simulations/BallAcceleration.jsx
+++ b/simulations/BallAcceleration.jsx
@@ -118,7 +118,8 @@ export default function BallAcceleration() {
         if (!bodyRef.current) return;
 
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+
+        if (dt === 0) return;
 
         const { size, acceleration, maxspeed, color, trailEnabled } =
           inputsRef.current;

--- a/simulations/BallGravity.jsx
+++ b/simulations/BallGravity.jsx
@@ -138,7 +138,7 @@ export default function BallGravity() {
         if (!bodyRef.current) return;
 
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         const {
           mass,

--- a/simulations/BouncingBall.jsx
+++ b/simulations/BouncingBall.jsx
@@ -146,7 +146,7 @@ export default function BouncingBall() {
         if (!bodyRef.current || !trailLayer) return;
 
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         const { size, gravity, trailEnabled, ballColor, mass, restitution } =
           inputsRef.current;

--- a/simulations/CircularMotion.jsx
+++ b/simulations/CircularMotion.jsx
@@ -117,7 +117,7 @@ export default function CircularMotion() {
         if (!bodyRef.current) return;
 
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         const { radius, speed, mass, size, color, trailEnabled } =
           inputsRef.current;

--- a/simulations/CollisionSimulation.jsx
+++ b/simulations/CollisionSimulation.jsx
@@ -235,7 +235,7 @@ export default function CollisionSimulation() {
         if (!bodiesRef.current.length || !trailLayer) return;
 
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         // Sync Visual Properties
         const { ballColor1, ballColor2, trailEnabled } = inputsRef.current;

--- a/simulations/DoublePendulum.jsx
+++ b/simulations/DoublePendulum.jsx
@@ -209,7 +209,7 @@ export default function DoublePendulum() {
         const inp = inputsRef.current;
         const { L1, L2 } = scaledLengthsRef.current;
 
-        if (dt > 0) {
+        if (dt !== 0) {
           const subSteps = 8;
           const subDt = dt / subSteps;
           for (let i = 0; i < subSteps; i++) {

--- a/simulations/HorizontalSpring.jsx
+++ b/simulations/HorizontalSpring.jsx
@@ -131,7 +131,7 @@ export default function HorizontalSpring() {
         if (!bodyRef.current || !springRef.current) return;
 
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         const { springK, springRestLength, bobMass, minCompressionLength } =
           inputsRef.current;

--- a/simulations/InclinedPlane.jsx
+++ b/simulations/InclinedPlane.jsx
@@ -184,7 +184,7 @@ export default function InclinedPlane() {
         );
 
         // Physics step (if not dragging)
-        if (!dragControllerRef.current.isDragging() && dt > 0) {
+        if (!dragControllerRef.current.isDragging() && dt !== 0) {
           bodyRef.current.stepAlongPlane(dt, forces.netParallel, angleRad);
 
           // Update trail

--- a/simulations/SimplePendulum.jsx
+++ b/simulations/SimplePendulum.jsx
@@ -53,7 +53,7 @@ class PendulumBody extends PhysicsBody {
    * Update using pendulum physics with constraint
    */
   stepPendulum(dt, gravity, damping) {
-    if (dt <= 0) return;
+    if (dt === 0) return;
 
     // Get current angle from vertical
     const dx = this.state.position.x - this.anchor.x;
@@ -268,7 +268,7 @@ export default function Pendulum() {
         bodyRef.current.trail.color = inputsRef.current.bobColor;
 
         // Physics step (if not dragging)
-        if (!dragControllerRef.current.isDragging() && dt > 0) {
+        if (!dragControllerRef.current.isDragging() && dt !== 0) {
           bodyRef.current.stepPendulum(
             dt,
             inputsRef.current.gravity,

--- a/simulations/SpringConnection.jsx
+++ b/simulations/SpringConnection.jsx
@@ -140,7 +140,7 @@ export default function SpringConnection() {
         if (!bodyRef.current || !springRef.current) return;
 
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         const {
           gravity,

--- a/simulations/ThreeBody.jsx
+++ b/simulations/ThreeBody.jsx
@@ -176,7 +176,7 @@ export default function ThreeBody() {
 
       p.draw = () => {
         const dt = Math.min(computeDelta(p), 1 / 30);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         const { G } = inputsRef.current;
         const bodies = bodiesRef.current;

--- a/simulations/test.jsx
+++ b/simulations/test.jsx
@@ -117,7 +117,7 @@ export default function Test() {
         const { gravity, numBodies, trailEnabled, restitution, frictionMu } =
           inputsRef.current;
         const dt = computeDelta(p);
-        if (dt <= 0) return;
+        if (dt === 0) return;
 
         // Recreate bodies if count changed
         if (numBodies !== lastNumBodies) {


### PR DESCRIPTION
## Summary

Closes #319

Adds Step Backward and Step Forward controls next to the Play/Pause button.

The buttons manually inject a fixed simulation delta while paused:

- Step Backward: `-0.01`
- Step Forward: `+0.01`

This helps users inspect simulations frame-by-frame without needing to pause at the exact moment.

## Changes

- Added a reusable `StepButton` control.
- Added manual step support to the shared time system.
- Updated simulation `dt` guards so negative manual steps are not ignored.
- Updated shared physics body stepping to allow non-zero negative deltas.

## Testing

- Ran the project locally with `npm run dev`.
- Confirmed step buttons appear in simulations.
- Tested forward and backward stepping while paused.
- Confirmed Play/Pause and Reset still work.
- Tested across multiple simulations.