### PR TITLE
fix: replace unreliable contributor stats aggregation workflow

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - feature/collision-simulation
     paths.ignore:
       - ".all-contributorsrc"
   workflow_dispatch:
@@ -33,7 +34,7 @@ jobs:
 
       - name: Debug GH_TOKEN
         run: echo "GH_TOKEN exists: ${{ secrets.GH_TOKEN != '' }}"
-        
+
       - name: Run contributors script
         run: npm run contributors
         env:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
+      - name: Debug GH_TOKEN
+        run: echo "GH_TOKEN exists: ${{ secrets.GH_TOKEN != '' }}"
+        
       - name: Run contributors script
         run: npm run contributors
         env:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - feature/collision-simulation
     paths.ignore:
       - ".all-contributorsrc"
   workflow_dispatch:
@@ -31,9 +30,6 @@ jobs:
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps
-
-      - name: Debug GH_TOKEN
-        run: echo "GH_TOKEN exists: ${{ secrets.GH_TOKEN != '' }}"
 
       - name: Run contributors script
         run: npm run contributors

--- a/scripts/contributors/contributors.ts
+++ b/scripts/contributors/contributors.ts
@@ -16,7 +16,7 @@ import {
   getPercentagesAdditions,
   getPercentagesDeletions,
 } from "../helpers/percentage.ts";
-import { getRemoteStats } from "../helpers/gitStats.ts";
+import { fetchAllStats, getStatsForAuthor } from "../helpers/gitStats.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -56,8 +56,12 @@ const fetchContributors = (
     const config: AxiosRequestConfig = {
       method: "get",
       url: `https://api.github.com/repos/physicshub/physicshub.github.io/contributors`,
-      params: { page },
+      params: {
+        page,
+        per_page: 100,
+      },
       headers: {
+        Authorization: `Bearer ${process.env.GH_TOKEN}`,
         accept: "application/json",
         "User-Agent": "Contributors script",
       },
@@ -69,13 +73,13 @@ const fetchContributors = (
         const { nextPage, lastPage, prevPage } = parseLinkHeader(
           res.headers?.link?.toString() ?? ""
         );
+        const totalPages =
+          lastPage?.[1] ??
+          (prevPage?.[1] ? String(Number(prevPage[1]) + 1) : "?");
+
         console.log(
           "> PhysicsHub:",
-          yellow(
-            `[${page}/${
-              lastPage ? lastPage[1] : +prevPage[1] + 1
-            }] Loading contributors from GitHub...`
-          )
+          yellow(`[${page}/${totalPages}] Loading contributors from GitHub...`)
         );
 
         resolve({ contributorsOfPage: res.data, nextPage: nextPage?.[1] });
@@ -176,18 +180,20 @@ const init = async () => {
     "> PhysicsHub:",
     yellow("Fetching remote stats for sorting by additions...")
   );
-  const contributorsStats: ContributorStats[] = await Promise.all(
-    contributorsList.map(async (c) => {
-      const stats = await getRemoteStats(c.login);
-      return {
-        login: c.login,
-        additions: stats.additions ?? 0,
-        deletions: stats.deletions ?? 0,
-        commits: stats.commits ?? 0,
-        originalContributor: c, // Mantiene l'oggetto originale
-      };
-    })
-  );
+  const allStats = await fetchAllStats();
+
+  const contributorsStats: ContributorStats[] = [];
+  for (const c of contributorsList) {
+    const stats = getStatsForAuthor(allStats, c.login);
+
+    contributorsStats.push({
+      login: c.login,
+      additions: stats.additions,
+      deletions: stats.deletions,
+      commits: stats.commits,
+      originalContributor: c,
+    });
+  }
 
   // 3. ORDINA LE STATISTICHE PER "ADDITIONS" IN ORDINE DISCENDENTE
   contributorsStats.sort((a, b) => b.additions - a.additions);
@@ -206,7 +212,7 @@ const init = async () => {
   // 6. CREA L'IMMAGINE
   console.log("> PhysicsHub:", yellow("Creating image..."));
   const fileName = "contributors";
-  createScreenshot(outputPath, fileName)
+  await createScreenshot(outputPath, fileName)
     .then(() => {
       console.log(
         "> PhysicsHub:",

--- a/scripts/helpers/gitStats.ts
+++ b/scripts/helpers/gitStats.ts
@@ -3,102 +3,235 @@ import axios from "axios";
 import { green, red, yellow } from "../helpers/painter.ts";
 
 export interface ContributorStats {
-  additions: number | null;
-  deletions: number | null;
-  commits: number | null;
+  additions: number;
+  deletions: number;
+  commits: number;
 }
 
-interface GitHubContributor {
+export interface AggregatedContributorStats {
+  [login: string]: ContributorStats;
+}
+
+interface GitHubCommit {
+  sha: string;
   author: {
     login: string;
-  };
-  weeks: Array<{
-    a: number; // additions
-    d: number; // deletions
-    c: number; // commits
-  }>;
+  } | null;
 }
 
+interface ParentCommit {
+  sha: string;
+}
+interface GitHubCommitDetails {
+  stats: {
+    additions: number;
+    deletions: number;
+    total: number;
+  };
+  author: {
+    login: string;
+  } | null;
+  parents: ParentCommit[];
+}
+
+let cachedStats: AggregatedContributorStats | null = null;
+
 /**
- * Poll GitHub API until stats are ready.
- * @param author GitHub username
- * @param maxRetries Numero massimo di tentativi
- * @param delayMs Millisecondi di attesa tra i retry
+ * Fetch all contributor stats using commit aggregation
  */
-export const getRemoteStats = async (
-  author: string,
-  maxRetries = 10,
-  delayMs = 5000
-): Promise<ContributorStats> => {
+export const fetchAllStats = async (): Promise<AggregatedContributorStats> => {
   if (!process.env.GH_TOKEN) {
-    console.log(red("GH_TOKEN isn't defined. Define it on .env file"));
-    return { additions: null, deletions: null, commits: null };
+    console.log(red("GH_TOKEN isn't defined. Define it in your .env file."));
+    return {};
   }
 
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    try {
-      const res = await axios.get(
-        `https://api.github.com/repos/physicshub/physicshub.github.io/stats/contributors`,
+  // Use cache
+  if (cachedStats) {
+    console.log(green("Using cached contributor stats"));
+    return cachedStats;
+  }
+
+  const repository = "physicshub/physicshub.github.io";
+
+  console.log(
+    green(`Fetching contributor stats from repository: ${repository}`)
+  );
+
+  const aggregatedStats: AggregatedContributorStats = {};
+
+  try {
+    let page = 1;
+    let hasMore = true;
+    let totalCommitsProcessed = 0;
+
+    while (hasMore) {
+      console.log(yellow(`Fetching commits page ${page}...`));
+
+      const commitsResponse = await axios.get(
+        `https://api.github.com/repos/${repository}/commits`,
         {
+          params: {
+            per_page: 100,
+            page,
+          },
           headers: {
             accept: "application/json",
             "User-Agent": "Contributors script",
-            ...(process.env.GH_TOKEN
-              ? { Authorization: `token ${process.env.GH_TOKEN}` }
-              : {}),
+            Authorization: `Bearer ${process.env.GH_TOKEN}`,
           },
         }
       );
 
-      const contributors = res.data;
+      const commits: GitHubCommit[] = commitsResponse.data;
 
-      // Se la risposta non è ancora pronta (202 Accepted)
-      if (!Array.isArray(contributors)) {
-        console.warn(
+      console.log(green(`Fetched ${commits.length} commits from page ${page}`));
+
+      // Stop pagination
+      if (!commits.length) {
+        hasMore = false;
+        break;
+      }
+
+      // Chunk processing
+      const chunkSize = 5;
+
+      for (let i = 0; i < commits.length; i += chunkSize) {
+        const chunk = commits.slice(i, i + chunkSize);
+
+        console.log(
           yellow(
-            `Stats not ready yet for ${author}. Attempt ${attempt}/${maxRetries}`
+            `Processing commits ${i + 1} - ${Math.min(
+              i + chunkSize,
+              commits.length
+            )} from page ${page}`
           )
         );
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-        continue;
+
+        await Promise.all(
+          chunk.map(async (commit) => {
+            if (!commit.author?.login) {
+              return;
+            }
+
+            try {
+              const commitDetailsResponse = await axios.get(
+                `https://api.github.com/repos/${repository}/commits/${commit.sha}`,
+                {
+                  headers: {
+                    accept: "application/json",
+                    "User-Agent": "Contributors script",
+                    Authorization: `Bearer ${process.env.GH_TOKEN}`,
+                  },
+                }
+              );
+              const commitDetails: GitHubCommitDetails =
+                commitDetailsResponse.data;
+
+              // Skip merge commits
+              if (commitDetails.parents.length > 1) {
+                return;
+              }
+              const login = commit.author.login.toLowerCase();
+
+              if (!aggregatedStats[login]) {
+                aggregatedStats[login] = {
+                  additions: 0,
+                  deletions: 0,
+                  commits: 0,
+                };
+
+                console.log(green(`New contributor detected: ${login}`));
+              }
+
+              aggregatedStats[login].commits += 1;
+
+              aggregatedStats[login].additions +=
+                commitDetails.stats?.additions ?? 0;
+
+              aggregatedStats[login].deletions +=
+                commitDetails.stats?.deletions ?? 0;
+
+              totalCommitsProcessed += 1;
+            } catch (error: unknown) {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              console.warn(
+                yellow(
+                  `Failed to fetch commit details for ${commit.sha}: ${message}`
+                )
+              );
+            }
+          })
+        );
       }
 
-      const contributor = contributors.find(
-        (c: GitHubContributor) =>
-          c.author?.login?.toLowerCase() === author.toLowerCase()
-      );
-
-      if (!contributor) {
-        console.warn(yellow(`No stats found for ${author}.`));
-        return { additions: 0, deletions: 0, commits: 0 };
-      }
-
-      let additions = 0;
-      let deletions = 0;
-      let commits = 0;
-
-      contributor.weeks.forEach((week: { a: number; d: number; c: number }) => {
-        additions += week.a;
-        deletions += week.d;
-        commits += week.c;
-      });
-
-      console.log(green(`Stats found for ${author}.`));
-      return { additions, deletions, commits };
-    } catch {
-      console.error(
-        red(
-          `Error fetching stats for ${author}. Attempt ${attempt}/${maxRetries}`
+      console.log(
+        green(
+          `Completed processing page ${page}. Total processed commits: ${totalCommitsProcessed}`
         )
       );
-      // aspetta e riprova invece di uscire subito
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+      page += 1;
     }
+
+    console.log(
+      green(
+        `Successfully aggregated stats for ${
+          Object.keys(aggregatedStats).length
+        } contributors`
+      )
+    );
+    console.log("\n=== Aggregated Contributors ===\n");
+    Object.keys(aggregatedStats)
+      .sort()
+      .forEach((login, index) => {
+        console.log(`${index + 1}. ${login}`);
+      });
+    console.log(
+      `\nTotal aggregated contributors: ${Object.keys(aggregatedStats).length}`
+    );
+    console.log("\nTop contributors stats:\n");
+
+    Object.entries(aggregatedStats)
+      .sort((a, b) => b[1].additions - a[1].additions)
+      .slice(0, 20)
+      .forEach(([login, stats], index) => {
+        console.log(
+          `${index + 1}. ${login}
+       commits: ${stats.commits}
+       additions: ${stats.additions}
+       deletions: ${stats.deletions}\n`
+        );
+      });
+
+    cachedStats = aggregatedStats;
+
+    return aggregatedStats;
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(red(`Failed to fetch contributor stats: ${message}`));
+
+    return {};
+  }
+};
+
+// Get stats for a specific contributor
+
+export const getStatsForAuthor = (
+  stats: AggregatedContributorStats,
+  login: string
+): ContributorStats => {
+  const contributorStats = stats[login.toLowerCase()];
+
+  if (!contributorStats) {
+    console.warn(yellow(`No aggregated stats found for ${login}`));
+
+    return {
+      additions: 0,
+      deletions: 0,
+      commits: 0,
+    };
   }
 
-  // se dopo maxRetries non sono pronti
-  console.warn(
-    red(`Stats not available for ${author} after ${maxRetries} attempts.`)
-  );
-  return { additions: null, deletions: null, commits: null };
+  return contributorStats;
 };

--- a/scripts/helpers/screenshots.ts
+++ b/scripts/helpers/screenshots.ts
@@ -1,5 +1,5 @@
 // scripts/helpers/screenshots.ts
-import { join } from "node:path";
+
 import Puppeteer from "puppeteer";
 import { pathToFileURL } from "url";
 

--- a/scripts/helpers/screenshots.ts
+++ b/scripts/helpers/screenshots.ts
@@ -1,6 +1,7 @@
 // scripts/helpers/screenshots.ts
 import { join } from "node:path";
 import Puppeteer from "puppeteer";
+import { pathToFileURL } from "url";
 
 /**
  * Create a screenshot from an HTML file and save it as image.
@@ -12,7 +13,7 @@ export const createScreenshot = async (filePath: string, fileName: string) => {
     headless: true,
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
   });
-  const htmlFilePath = join("file:", filePath);
+  const htmlFilePath = pathToFileURL(filePath).href;
 
   try {
     const page = await browser.newPage();


### PR DESCRIPTION
# 📘 Pull Request – Fix contributor image generation and stats aggregation

## 🔍 Description

This PR fixes the broken contributor image generation workflow and refactors the contributor statistics aggregation system by replacing the unreliable `/stats/contributors` endpoint polling workflow with commit-history aggregation using the GitHub commits API.

### Main improvements

* Fixed contributor image generation by correcting local HTML file path handling for Puppeteer screenshot rendering
* Removed repeated per-contributor stats polling
* Implemented bulk commit aggregation
* Added commit pagination handling
* Added merge-commit filtering to better match GitHub Insights
* Reduced unnecessary API calls
* Improved contributor stats caching

The new implementation now:

* correctly generates the contributor image locally and in workflow environments,
* aggregates additions/deletions/commits directly from repository commit history,
* updates automatically when new commits are added,
* avoids dependency on GitHub’s frequently delayed `202 Accepted` stats endpoint.

Most contributor statistics now closely match GitHub Insights. Only 2–3 contributors (mainly large maintainer/bot accounts) still show small additions/deletions differences, likely due to GitHub internal aggregation heuristics.

Closes #318

---

## ✅ Checklist

* [x] Verified that the project builds and runs locally (`npm run dev`)
* [x] Ensured no ESLint or TypeScript warnings/errors remain
* [x] Updated documentation/comments where needed
* [x] Followed the CONTRIBUTING.md guidelines

---

## 🎨 Visual Changes (if UI-related)

No UI changes.

---

## 📂 Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ♻️ Refactor / code quality improvement

---

## 🧩 Additional Notes for Reviewers

GitHub contributor statistics are now generated using commit-history aggregation instead of relying on `/stats/contributors`, which frequently returned incomplete `202 Accepted` responses during testing.

The implementation now performs:

* bulk commit fetching,
* commit-detail aggregation,
* merge exclusion,
* contributor caching,
* automatic stats updates on new commits.
