### PR TITLE
fix: restore getTimeScale() in VectorsOperations so physics body moves

### DIFF
--- a/simulations/VectorsOperations.jsx
+++ b/simulations/VectorsOperations.jsx
@@ -11,6 +11,7 @@ import {
   resetTime,
   isPaused,
   setPause,
+  getTimeScale,
 } from "../app/(core)/constants/Time.js";
 import {
   INITIAL_INPUTS,
@@ -151,7 +152,7 @@ export default function VectorsOperations() {
         }
 
         // Apply global time scale and pause
-        const scale = 0; //getTimeScale();
+        const scale = getTimeScale();
         if (!isPaused()) {
           accumulator += dt * Math.max(0, scale);
         }


### PR DESCRIPTION

# 📘 Pull Request Template – PhysicsHub

Thank you for contributing to **PhysicsHub**!  
Please complete the sections below to help us review your pull request efficiently.

---

## 🔍 Description

  What was wrong

  When physicsEnabled is turned on in the Vector Operations simulation, a physics ball is supposed to appear and move
  around the canvas responding to forces. It showed up on screen but was completely frozen — no movement at all.

  The cause: a debug leftover on one line:
  const scale = 0; //getTimeScale();
  The physics accumulator was being multiplied by 0 every frame, so the Planck.js world was never stepped forward, and
   the ball never moved.

  Fix

  Restored the original getTimeScale() call and added it to the imports from Time.js:
  const scale = getTimeScale(); // was: const scale = 0;

Closes #BUG-003 (if applicable)

---

## ✅ Checklist

Before requesting a review, please ensure that you have:

- [x] Verified that the project builds and runs locally (`npm run dev`)
- [x] Ensured no ESLint or TypeScript warnings/errors remain
- [x] Updated documentation, comments, or in-code explanations where needed
- [x] Verified responsiveness across devices (desktop, tablet, mobile)
- [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

---

## 🎨 Visual Changes (if UI-related)

IF CHANGES ARE RELATED TO SIMULATIONS PLEASE SEND A SHORT CLIP ABOUT IT
(OBLIGATORY)

<!-- Attach screenshots, GIFs, or screen recordings to illustrate UI/UX changes. -->

---

## 📂 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / code quality improvement
- [ ] 🎨 UI/UX enhancement
- [ ] 🔒 Security improvement

---

## 🧩 Additional Notes for Reviewers

<!-- Highlight specific areas that need attention, potential edge cases, or architectural decisions. -->
