### PR TITLE
fix: correct parallelogram visualization for vector subtraction

### DIFF
--- a/simulations/VectorsOperations.jsx
+++ b/simulations/VectorsOperations.jsx
@@ -320,15 +320,6 @@ export default function VectorsOperations() {
               p.strokeWeight(strokeWeight + 1);
               p.line(0, 0, Rvec_sub_par.x, Rvec_sub_par.y);
 
-              p.stroke(adjustColor(strokeColor));
-              p.strokeWeight(Math.max(1, strokeWeight - 0.2));
-              p.line(
-                Avec_sub_par.x,
-                Avec_sub_par.y,
-                Bvec_sub_par.x,
-                Bvec_sub_par.y
-              );
-
               p.noStroke();
               p.fill(255, 220, 120);
               p.circle(Avec_sub_par.x, Avec_sub_par.y, 7);


### PR DESCRIPTION
Fixes #87

The parallelogram subtraction visualization was drawing a spurious line 
from the tip of vector A to the tip of vector B, which had no geometric 
meaning and made the diagram look broken.

Removed the incorrect p.line() call so the visualization now correctly 
shows B and -A as adjacent sides of the parallelogram, with the diagonal 
R = B + (-A) as the resultant.