### PR TITLE
fix: remove unused variables and imports causing build warnings

### DIFF
--- a/app/(core)/components/Layout.jsx
+++ b/app/(core)/components/Layout.jsx
@@ -12,7 +12,7 @@ export default function Layout({
   starColor = "AEE3FF",
   starOpacity = 0.4,
 }) {
-  const { t, meta } = useTranslation();
+  const { meta } = useTranslation();
   const isCompleted = meta?.completed || false;
   return (
     <>

--- a/app/(core)/components/P5Wrapper.jsx
+++ b/app/(core)/components/P5Wrapper.jsx
@@ -48,7 +48,7 @@ const loadP5Library = (() => {
           cached = P5;
           return resolve(cached);
         }
-      } catch (_) {}
+      } catch {}
 
       if (typeof window.p5 === "function") {
         cached = window.p5;
@@ -103,7 +103,7 @@ export default function P5Wrapper({ sketch, simInfos }) {
     try {
       cleanupInstance(instance);
       instance.remove();
-    } catch (_) {}
+    } catch {}
   };
 
   // Centralised resize logic
@@ -154,7 +154,6 @@ export default function P5Wrapper({ sketch, simInfos }) {
               // body spawn positions use the correct canvas dimensions even
               // when p._userNode.clientHeight is still 0 at this point.
               const h = containerRef.current?.clientHeight ?? 0;
-              const w = containerRef.current?.clientWidth ?? 0;
               if (h > 0) setCanvasHeight(h);
 
               // Run the sketch's own setup (calls p.createCanvas internally).

--- a/app/(core)/components/Screen.jsx
+++ b/app/(core)/components/Screen.jsx
@@ -6,7 +6,7 @@ import useTranslation from "../hooks/useTranslation.ts";
 function Screen({ sketch }) {
   const containerRef = useRef(null);
   const p5Instance = useRef(null);
-  const { t, meta } = useTranslation();
+  const { meta } = useTranslation();
   const isCompleted = meta?.completed || false;
 
   useEffect(() => {

--- a/app/(core)/components/SimulationLayout.jsx
+++ b/app/(core)/components/SimulationLayout.jsx
@@ -18,7 +18,7 @@ export default function SimulationLayout({
   children,
   dynamicInputs,
 }) {
-  const { t, meta } = useTranslation();
+  const { meta } = useTranslation();
   const isCompleted = meta?.completed || false;
 
   const theory = useMemo(() => {

--- a/app/(pages)/blog/[slug]/page.jsx
+++ b/app/(pages)/blog/[slug]/page.jsx
@@ -1,17 +1,6 @@
 import { blogsArray } from "../../../(core)/data/articles/index.js";
 import { notFound } from "next/navigation";
-import TheoryRenderer from "../../../(core)/components/theory/TheoryRenderer.tsx";
-import Tag from "../../../(core)/components/Tag.jsx";
-import BlogInteractions from "../../../(core)/components/blog/BlogInteractions.tsx";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faClock,
-  faChevronRight,
-  faArrowLeft,
-  faArrowRight,
-} from "@fortawesome/free-solid-svg-icons";
-import Link from "next/link";
-import Image from "next/image";
+
 import {
   getReadingTime,
   getTitles,


### PR DESCRIPTION
Fixes all ESLint warnings that appeared during npm run build/preview.

Changes:
- blog/[slug]/page.jsx: removed unused imports (TheoryRenderer, Tag, 
  BlogInteractions, FontAwesomeIcon, fa* icons, Link, Image) that were 
  moved to BlogPostContent.jsx
- Layout.jsx, Screen.jsx, SimulationLayout.jsx: removed unused `t` 
  from useTranslation() destructuring
- P5Wrapper.jsx: replaced catch(_) with catch{} to avoid unused 
  parameter warning, removed unused `w` variable

Build now produces zero warnings.