### PR TITLE
Fix Circular Motion: derive velocity from centripetal force instead of forcing constant speed

### DIFF
--- a/simulations/CircularMotion.jsx
+++ b/simulations/CircularMotion.jsx
@@ -148,9 +148,12 @@ export default function CircularMotion() {
           bodyRef.current.applyForce(centripetalForce);
         }
 
-        // Enforce constant speed
-        if (bodyRef.current.state.velocity.mag() > 0) {
-          bodyRef.current.state.velocity.setMag(speed);
+        // Gently correct for numerical drift (instead of forcing speed every frame)
+        const currentSpeed = bodyRef.current.state.velocity.mag();
+        if (currentSpeed > 0) {
+          const correctionFactor =
+            1 + ((speed - currentSpeed) / currentSpeed) * 0.05;
+          bodyRef.current.state.velocity.mult(correctionFactor);
         }
 
         // Step physics


### PR DESCRIPTION
Closes part of #40

**Problem:** In CircularMotion.jsx, the centripetal force was correctly calculated (F = ma) and applied via applyForce(), but the velocity was then immediately overridden every frame with setMag(speed). This meant the force calculation had no real effect on the motion — it was purely decorative for the visual arrow, and the circular path came from the artificial override, not actual physics.

**Fix:** Replaced the hard override with a gentle correction (5% per frame) that lets the applied centripetal force genuinely drive the velocity's rotation, while still correcting for small numerical drift so the orbit doesn't spiral over many frames.

**Testing:** Ran the simulation for 15-20+ seconds — orbit stays stable with no visible spiral-in or spiral-out. Confirmed the path remains a clean circle.