### PR TITLE
fix: correct restitution label from Damping to Coefficient of restitution

### DIFF
--- a/app/(core)/data/configs/BallGravity.js
+++ b/app/(core)/data/configs/BallGravity.js
@@ -57,7 +57,7 @@ export const INPUT_FIELDS = [
   },
   {
     name: "restitution",
-    label: "ζ - Damping:",
+    label: "e - Coefficient of restitution (0–1):",
     type: "number",
     min: 0,
     max: 1,

--- a/app/(core)/data/configs/BouncingBall.js
+++ b/app/(core)/data/configs/BouncingBall.js
@@ -34,7 +34,7 @@ export const INPUT_FIELDS = [
   },
   {
     name: "restitution",
-    label: "ζ - Damping:",
+    label: "e - Coefficient of restitution (0–1):",
     type: "number",
     min: 0,
     max: 2,


### PR DESCRIPTION

## 🔍 Description

   The `restitution` input field in the **BallGravity** and **BouncingBall** simulation control panels was
   incorrectly labelled `ζ - Damping:`. This is wrong on two counts:

   - **Wrong symbol**: `ζ` (zeta) is the convention for the *damping ratio* in oscillatory systems (pendulums,
   spring-mass), not for collision elasticity.
   - **Wrong concept**: This parameter controls how much kinetic energy is preserved after a bounce — that is the
   **coefficient of restitution** (`e`), not damping. Damping describes *continuous* energy loss during motion;
   restitution describes the energy ratio across a *discrete impact*.

   The `CollisionSimulation` config already correctly labels the same variable as `e - Restitution:` — this PR
   makes `BallGravity` and `BouncingBall` consistent with it.

   Closes #189

   ---

   ## ✅ Checklist

   - [x] Verified that the project builds and runs locally (`npm run dev`)
   - [x] Ensured no ESLint or TypeScript warnings/errors remain
   - [x] Updated documentation, comments, or in-code explanations where needed
   - [x] Verified responsiveness across devices (desktop, tablet, mobile)
   - [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

   ---

   ## 🎨 Visual Changes (if UI-related)

   This is a **label-only change** in the simulation control panel. The input behaviour, range, and step values are
    unchanged.

   **Before:**
   > `ζ - Damping:` (shown in BallGravity and BouncingBall control panels)

   **After:**
   > `e - Coefficient of restitution (0–1):` (consistent with CollisionSimulation)

   ---

   ## 📂 Type of Change

   - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
   - [ ] ✨ New feature (non-breaking change that adds functionality)
   - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
   - [ ] 📝 Documentation update
   - [ ] ♻️  Refactor / code quality improvement
   - [ ] 🎨 UI/UX enhancement
   - [ ] 🔒 Security improvement

   ---

   ## 🧩 Additional Notes for Reviewers

   Only two lines changed across two config files — no logic, no range, no defaults touched:

   - `app/(core)/data/configs/BallGravity.js` line 60
   - `app/(core)/data/configs/BouncingBall.js` line 37## 🔍 Description

   The `restitution` input field in the **BallGravity** and **BouncingBall** simulation control panels was
   incorrectly labelled `ζ - Damping:`. This is wrong on two counts:

   - **Wrong symbol**: `ζ` (zeta) is the convention for the *damping ratio* in oscillatory systems (pendulums,
   spring-mass), not for collision elasticity.
   - **Wrong concept**: This parameter controls how much kinetic energy is preserved after a bounce — that is the
   **coefficient of restitution** (`e`), not damping. Damping describes *continuous* energy loss during motion;
   restitution describes the energy ratio across a *discrete impact*.

   The `CollisionSimulation` config already correctly labels the same variable as `e - Restitution:` — this PR
   makes `BallGravity` and `BouncingBall` consistent with it.

   Closes #189

   ---

   ## ✅ Checklist

   - [x] Verified that the project builds and runs locally (`npm run dev`)
   - [x] Ensured no ESLint or TypeScript warnings/errors remain
   - [x] Updated documentation, comments, or in-code explanations where needed
   - [x] Verified responsiveness across devices (desktop, tablet, mobile)
   - [x] Followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

   ---

   ## 🎨 Visual Changes (if UI-related)

   This is a **label-only change** in the simulation control panel. The input behaviour, range, and step values are
    unchanged.

   **Before:**
   > `ζ - Damping:` (shown in BallGravity and BouncingBall control panels)

   **After:**
   > `e - Coefficient of restitution (0–1):` (consistent with CollisionSimulation)

   <!-- Screenshot/clip showing the label before and after — attach below -->

   ---

   ## 📂 Type of Change

   - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
   - [ ] ✨ New feature (non-breaking change that adds functionality)
   - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
   - [ ] 📝 Documentation update
   - [ ] ♻️  Refactor / code quality improvement
   - [ ] 🎨 UI/UX enhancement
   - [ ] 🔒 Security improvement

   ---

   ## 🧩 Additional Notes for Reviewers

   Only two lines changed across two config files — no logic, no range, no defaults touched:

   - `app/(core)/data/configs/BallGravity.js` line 60
   - `app/(core)/data/configs/BouncingBall.js` line 37
 Both changed from `"ζ - Damping:"` → `"e - Coefficient of restitution (0–1):"`.
