### PR TITLE
fix: improve sitemap generator for better Google Search Console compatibility

### DIFF
--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -1,32 +1,44 @@
 // sitemap-generator.js
 import { SitemapStream, streamToPromise } from "sitemap";
-import { writeFileSync } from "fs";
+import { writeFileSync, existsSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
 import xmlFormat from "xml-formatter";
 
 import { routes as staticRoutes } from "../routes.js";
 import { blogsArray } from "../app/(core)/data/articles/index.js";
 import chapters from "../app/(core)/data/chapters.js";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 const hostname = "https://physicshub.github.io";
 const sitemapName = "sitemap";
 
+// Current date in W3C format (YYYY-MM-DD) for lastmod
+const getCurrentDate = () => new Date().toISOString().split("T")[0];
+
 function updateRoutesFile(allRoutes) {
   const content = `export const routes = ${JSON.stringify(allRoutes, null, 2)};`;
-  writeFileSync("../routes.js", content);
+  writeFileSync(join(__dirname, "../routes.js"), content);
   console.log("✅ routes.js physical file updated!");
 }
 
 async function generateSitemap() {
+  const currentDate = getCurrentDate();
+
   const blogRoutes = blogsArray.map((blog) => ({
     path: `/blog/${blog.slug}`,
     changefreq: "monthly",
     priority: 0.8,
+    lastmod: currentDate,
   }));
 
   const simulationRoutes = chapters.map((chapter) => ({
     path: chapter.link,
     changefreq: "weekly",
     priority: 0.7,
+    lastmod: currentDate,
   }));
 
   const combinedRoutes = [...staticRoutes, ...blogRoutes, ...simulationRoutes];
@@ -37,55 +49,81 @@ async function generateSitemap() {
   });
   const allRoutes = Array.from(uniqueRoutesMap.values());
 
-  const sitemap = new SitemapStream({ hostname });
+  // Generate sitemap with only the required namespace
+  // Removing unused news, xhtml, image, video namespaces that can confuse crawlers
+  const sitemap = new SitemapStream({
+    hostname,
+    xmlns: {
+      news: false,
+      xhtml: false,
+      image: false,
+      video: false,
+    },
+  });
 
   allRoutes.forEach((route) => {
     sitemap.write({
       url: route.path,
       changefreq: route.changefreq,
       priority: route.priority,
+      lastmod: route.lastmod || currentDate,
     });
   });
 
   sitemap.end();
 
   const rawXml = (await streamToPromise(sitemap)).toString();
+
+  // Add XML declaration and format
   const formatted = xmlFormat(rawXml, {
     indentation: "  ",
     collapseContent: true,
+    lineSeparator: "\n",
   });
 
-  writeFileSync(`./public/${sitemapName}.xml`, formatted);
-  console.log(`✅ Sitemap generated with ${allRoutes.length} links!`);
+  const xmlOutput = `<?xml version="1.0" encoding="UTF-8"?>\n${formatted}`;
 
-  try {
-    const fs = await import("fs");
-    if (fs.existsSync("./out")) {
-      writeFileSync(`./out/${sitemapName}.xml`, formatted);
-      console.log(`✅ Sitemap copied to ./out!`);
-    }
-  } catch (e) {
-    console.error("Error writing to out directory:", e);
+  // Ensure public directory exists
+  const publicDir = join(__dirname, "../public");
+  if (!existsSync(publicDir)) {
+    mkdirSync(publicDir, { recursive: true });
   }
 
-  // Robots.txt
+  // Write to public directory
+  const publicPath = join(publicDir, `${sitemapName}.xml`);
+  writeFileSync(publicPath, xmlOutput);
+  console.log(`✅ Sitemap generated with ${allRoutes.length} links in public/`);
+
+  // Also write to out/ if it exists (for deployment consistency)
+  const outDir = join(__dirname, "../out");
+  if (existsSync(outDir)) {
+    writeFileSync(join(outDir, `${sitemapName}.xml`), xmlOutput);
+    console.log(`✅ Sitemap copied to ./out/`);
+  }
+
+  // Generate robots.txt with sitemap reference
   const robotsTxt =
     `User-agent: *\nAllow: /\n\nSitemap: ${hostname}/${sitemapName}.xml`.trim();
-  writeFileSync("./public/robots.txt", robotsTxt);
 
-  try {
-    const fs = await import("fs");
-    if (fs.existsSync("./out")) {
-      writeFileSync("./out/robots.txt", robotsTxt);
-      console.log(`✅ Robots.txt copied to ./out!`);
-    }
-  } catch (e) {
-    console.error("Error writing robots.txt to out directory:", e);
+  writeFileSync(join(publicDir, "robots.txt"), robotsTxt);
+  console.log("✅ robots.txt updated in public/");
+
+  if (existsSync(outDir)) {
+    writeFileSync(join(outDir, "robots.txt"), robotsTxt);
+    console.log("✅ robots.txt copied to ./out/");
   }
 
-  console.log("✅ Robots.txt updated!");
-
   updateRoutesFile(allRoutes);
+
+  console.log("\n📋 Sitemap Summary:");
+  console.log(`   - Total URLs: ${allRoutes.length}`);
+  console.log(`   - Lastmod date: ${currentDate}`);
+  console.log(
+    `   - Unused namespaces removed for better crawler compatibility`
+  );
 }
 
-generateSitemap();
+generateSitemap().catch((err) => {
+  console.error("❌ Error generating sitemap:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
# 📘 Pull Request Template – PhysicsHub

Thank you for contributing to **PhysicsHub**!  
Please complete the sections below to help us review your pull request efficiently.

---

## 🔍 Description
  Improves the sitemap generation script to resolve the Google Search Console
  indexing issue (#107):

  - Removes unused XML namespaces (`news`, `xhtml`, `image`, `video`) that were
    declared but never used — these can confuse crawlers
  - Adds `<lastmod>` dates to all URLs (blog, simulation, and static routes)
  - Adds explicit `<?xml version="1.0" encoding="UTF-8"?>` declaration
  - Uses `path.join()` + `__dirname` for correct cross-platform file paths
  - Ensures `public/` directory exists before writing (defensive)
  - Simplifies `out/` directory handling using `existsSync` (removes dynamic imports)
  - Adds `process.exit(1)` on failure so CI fails visibly if sitemap errors
  - Adds summary output for verification

  This replicates the approach from PR #290 with Prettier formatting applied.

  ## ✅ Checklist
  - [x] I have read the CONTRIBUTING.md
  - [x] My changes follow the code style of this project
  - [x] I ran `npm run format` — Prettier passes on the changed file
  - [x] No new ESLint errors introduced

  ## 🎨 Visual Changes
  No UI changes — build script only.

  ## 📂 Type of Change
  - [x] Bug fix

  ## 🧩 Additional Notes for Reviewers
  This is a re-implementation of PR #290 which the maintainer said would be merged
  if prettier errors were fixed. Prettier has been applied and the file passes
  `npx prettier --check scripts/sitemap-generator.js`. The current file also
  includes the `simulationRoutes` (added after #290 was opened), which have been
  given `lastmod` dates as well.