### PR TITLE
fix(i18n): remove trailing comma breaking JSON in locales meta

### DIFF
--- a/app/(core)/locales/meta.json
+++ b/app/(core)/locales/meta.json
@@ -30,5 +30,5 @@
   "id": {
     "name": "Bahasa Indonesia",
     "completed": true
-  },
+  }
 }


### PR DESCRIPTION
## What
Removes a trailing comma after the `id` (Bahasa Indonesia) entry in `app/(core)/locales/meta.json`, introduced by #380.

## Why
The trailing comma makes the file invalid JSON. Next's webpack JSON loader fails to parse it when `useTranslation.ts` imports it, so `npm run build` (and thus the `Release and Build` deploy workflow) fails on `main` with:

```
Module parse failed: Cannot parse JSON: Expected double-quoted property name in JSON at position 493
./app/(core)/locales/meta.json
./app/(core)/hooks/useTranslation.ts
./app/not-found.jsx
```

Confirmed against the failed run: https://github.com/physicshub/physicshub.github.io/actions/runs/33857119902

## Verification
- `python3 -m json.tool app/(core)/locales/meta.json` — valid
- `npm run build` — succeeds locally (exit 0), export completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)